### PR TITLE
[fix] 로그아웃 후 재로그인 시 unique constraint 오류 해결

### DIFF
--- a/src/test/java/app/mockly/domain/auth/service/AuthServiceIntegrationTest.java
+++ b/src/test/java/app/mockly/domain/auth/service/AuthServiceIntegrationTest.java
@@ -1,0 +1,100 @@
+package app.mockly.domain.auth.service;
+
+import app.mockly.domain.auth.dto.DeviceInfo;
+import app.mockly.domain.auth.dto.LocationInfo;
+import app.mockly.domain.auth.dto.request.DevLoginRequest;
+import app.mockly.domain.auth.dto.response.LoginResponse;
+import app.mockly.domain.auth.entity.Session;
+import app.mockly.domain.auth.repository.RefreshTokenRepository;
+import app.mockly.domain.auth.repository.SessionRepository;
+import app.mockly.domain.auth.repository.UserRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+
+@SpringBootTest
+@Transactional
+@DisplayName("AuthService 통합 테스트")
+public class AuthServiceIntegrationTest {
+    @Autowired
+    private AuthService authService;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private SessionRepository sessionRepository;
+
+    @Autowired
+    private RefreshTokenRepository refreshTokenRepository;
+
+    @MockitoBean
+    private TokenBlacklistService tokenBlacklistService;
+
+    @Test
+    @DisplayName("로그아웃 후 같은 디바이스로 재로그인 시, 세션 재사용")
+    void logout_and_relogin_reuses_session() {
+        String email = "test@example.com";
+        String deviceId = "test-device-123";
+        DeviceInfo deviceInfo = new DeviceInfo(deviceId, "test device");
+        LocationInfo locationInfo = new LocationInfo(37.5, 127.0);
+        DevLoginRequest request = new DevLoginRequest(email, "test user", deviceInfo, locationInfo);
+
+        given(tokenBlacklistService.isBlacklisted(anyString())).willReturn(false);
+
+        // 1) 로그인
+        LoginResponse loginResponse1 = authService.loginWithDev(request);
+        Optional<Session> sessionAfterLogin1 = sessionRepository.findByUserAndDeviceId(userRepository.findByEmail(email).get(), deviceId);
+        assertThat(sessionAfterLogin1).isPresent();
+
+        // 2) 로그아웃
+        authService.logout(loginResponse1.accessToken(), loginResponse1.refreshToken());
+
+        // 3) 재로그인
+        LoginResponse loginResponse2 = authService.loginWithDev(request);
+        Optional<Session> sessionAfterLogin2 = sessionRepository.findByUserAndDeviceId(userRepository.findByEmail(email).get(), deviceId);
+
+        assertThat(sessionAfterLogin2.get().getId()).isEqualTo(sessionAfterLogin1.get().getId());
+        assertThat(loginResponse2.refreshToken()).isNotEqualTo(loginResponse1.refreshToken());
+
+        assertThat(refreshTokenRepository.findByToken(loginResponse1.refreshToken())).isEmpty();
+        assertThat(refreshTokenRepository.findByToken(loginResponse2.refreshToken())).isPresent();
+    }
+
+    @Test
+    @DisplayName("활성 세션에서 재로그인 시, 토큰 교체 및 old 토큰 삭제")
+    void active_session_relogin_replaces_token() {
+        String email = "test2@example.com";
+        String deviceId = "test-device-456";
+        DeviceInfo deviceInfo = new DeviceInfo(deviceId, "test device");
+        LocationInfo locationInfo = new LocationInfo(37.5, 127.0);
+        DevLoginRequest request = new DevLoginRequest(email, "test user", deviceInfo, locationInfo);
+
+        given(tokenBlacklistService.isBlacklisted(anyString())).willReturn(false);
+
+        // 1) 로그인
+        LoginResponse loginResponse1 = authService.loginWithDev(request);
+        String refreshToken1 = loginResponse1.refreshToken();
+        Long sessionId1 = sessionRepository.findByUserAndDeviceId(userRepository.findByEmail(email).get(), deviceId).get().getId();
+
+        // 2) 로그아웃 없이 재로그인
+        LoginResponse loginResponse2 = authService.loginWithDev(request);
+        String refreshToken2 = loginResponse2.refreshToken();
+        Long sessionId2 = sessionRepository.findByUserAndDeviceId(userRepository.findByEmail(email).get(), deviceId).get().getId();
+
+        assertThat(sessionId1).isEqualTo(sessionId2);
+        assertThat(refreshToken1).isNotEqualTo(refreshToken2);
+
+        assertThat(refreshTokenRepository.findByToken(refreshToken1)).isEmpty();
+        assertThat(refreshTokenRepository.findByToken(refreshToken2)).isPresent();
+    }
+}


### PR DESCRIPTION
## 개요
로그아웃 후 재로그인 시 발생하는 unique constraint violation 버그 수정 및 세션 관리 로직 개선

## 주요 변경 사항
### 🐛 버그 수정
#### [문제]
로그아웃 후 같은 디바이스로 재로그인 시 다음 오류 발생
```
ERROR: duplicate key value violates unique constraint "ukmaxrni3oxdwsgd0xkr5bw3sdc"
Detail: Key (session_id)=(2) already exists.
```
#### [원인]
- RefreshToken 삭제 시 명시적 delete()와 JPA orphanRemoval이 충돌
- JPA에 의한 SQL 실행 순서 문제로 새 토큰 INSERT → UPDATE 시점에 기존 토큰이 아직 삭제되지 않음
#### [해결]
- 모든 RefreshToken 삭제 로직을 orphanRemoval로 통일
- Session.updateRefreshToken(null)로 orphanRemoval 트리거
- OrphanRemovalAction이 우선 실행되어, 올바른 SQL 순서 보장

### 🔧 리팩토링
- AuthService 로직 개선
   - `loginWithDev()`, `loginWithGoogleCode()`: 명시적 delete() 제거
   - `logout()`: deleteByToken() 대신 updateRefreshToken(null) 사용
   - `removeOldestSessions(): 일관된 orphanRemoval 패턴 적용
- Session 재정의
   - Session은 Device History를 저장하는 것으로 로그아웃 후에도 유지된다.
   - RefreshToken은 활성 로그인 상태를 표현한다. (null = 로그아웃)
   - deviceId는 unique 제약으로 디바이스 당 하나의 Session을 사용한다.

### 🧪 테스트
AuthServiceIntegrationTest 추가:
- 로그아웃 후 재로그인 시 세션 재사용 검증
- 활성 세션 재로그인 시 토큰 교체 검증

## 다음에 해야 할 작업
- OpenAI 연동 및 프롬프트 작업
- 모든 세션 조회 API 구현 (GET /api/auth/sessions)
- 특정 세션 강제 로그아웃 API 구현 (DELETE /api/auth/sessions/{sessionId})
- 세션 관리를 위한 API 문서화