### PR TITLE
[fix] 토큰 갱신 시 디바이스 검증

### DIFF
--- a/src/main/java/app/mockly/domain/auth/controller/AuthController.java
+++ b/src/main/java/app/mockly/domain/auth/controller/AuthController.java
@@ -40,9 +40,12 @@ public class AuthController {
     }
 
     @PostMapping("/refresh")
-    public ResponseEntity<ApiResponse<RefreshTokenResponse>> refreshToken(@Valid @RequestBody RefreshTokenRequest request) {
+    public ResponseEntity<ApiResponse<RefreshTokenResponse>> refreshToken(
+            @RequestHeader("X-Device-Id") String deviceId,
+            @Valid @RequestBody RefreshTokenRequest request
+    ) {
         RefreshTokenResponse refreshTokenResponse = authService.refreshToken(
-                request.refreshToken(), request.deviceInfo(), request.locationInfo());
+                request.refreshToken(), deviceId, request.locationInfo());
         return ResponseEntity.ok(ApiResponse.success(refreshTokenResponse));
     }
 

--- a/src/main/java/app/mockly/domain/auth/dto/request/RefreshTokenRequest.java
+++ b/src/main/java/app/mockly/domain/auth/dto/request/RefreshTokenRequest.java
@@ -1,17 +1,11 @@
 package app.mockly.domain.auth.dto.request;
 
-import app.mockly.domain.auth.dto.DeviceInfo;
 import app.mockly.domain.auth.dto.LocationInfo;
-import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
 
 public record RefreshTokenRequest(
         @NotBlank(message = "Refresh Token은 필수입니다.")
         String refreshToken,
-        @Valid
-        @NotNull(message = "deviceInfo는 필수입니다.")
-        DeviceInfo deviceInfo,
         LocationInfo locationInfo // optional
 ) {
 }

--- a/src/test/java/app/mockly/domain/auth/controller/AuthControllerTest.java
+++ b/src/test/java/app/mockly/domain/auth/controller/AuthControllerTest.java
@@ -220,9 +220,10 @@ class AuthControllerTest {
     @Test
     @DisplayName("POST /api/auth/refresh - 성공")
     void refreshToken_Success() throws Exception {
-        RefreshTokenRequest request = new RefreshTokenRequest(validRefreshTokenValue, deviceInfo, locationInfo);
+        RefreshTokenRequest request = new RefreshTokenRequest(validRefreshTokenValue, locationInfo);
 
         mockMvc.perform(post("/api/auth/refresh")
+                        .header("X-Device-Id", deviceInfo.deviceId())
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
                 .andDo(print())

--- a/src/test/java/app/mockly/domain/auth/controller/docs/RefreshTokenDocs.java
+++ b/src/test/java/app/mockly/domain/auth/controller/docs/RefreshTokenDocs.java
@@ -3,20 +3,19 @@ package app.mockly.domain.auth.controller.docs;
 import app.mockly.common.ApiResponseDocs;
 import com.epages.restdocs.apispec.ResourceSnippetParameters;
 import com.epages.restdocs.apispec.SimpleType;
+import org.springframework.restdocs.headers.HeaderDescriptor;
 import org.springframework.restdocs.payload.FieldDescriptor;
 import org.springframework.restdocs.payload.JsonFieldType;
 
 import java.util.List;
 
+import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 
 public class RefreshTokenDocs {
 
     private static final List<FieldDescriptor> REQUEST_FIELDS = List.of(
             fieldWithPath("refreshToken").description("Refresh Token (7일 유효)").type(SimpleType.STRING),
-            fieldWithPath("deviceInfo").description("디바이스 정보").type(JsonFieldType.OBJECT),
-            fieldWithPath("deviceInfo.deviceId").description("디바이스 고유 ID").type(SimpleType.STRING),
-            fieldWithPath("deviceInfo.deviceName").description("디바이스 이름").type(SimpleType.STRING),
             fieldWithPath("locationInfo").description("위치 정보 (선택)").type(JsonFieldType.OBJECT).optional(),
             fieldWithPath("locationInfo.latitude").description("위도").type(SimpleType.NUMBER).optional(),
             fieldWithPath("locationInfo.longitude").description("경도").type(SimpleType.NUMBER).optional()
@@ -32,6 +31,9 @@ public class RefreshTokenDocs {
         return ResourceSnippetParameters.builder()
                 .summary("Access Token 갱신")
                 .description("Refresh Token으로 Access Token을 갱신합니다. Token Rotation이 적용되어 Access Token과 Refresh Token 모두 재발급됩니다.")
+                .requestHeaders(
+                        headerWithName("X-Device-Id").description("디바이스 고유 ID")
+                )
                 .requestFields(REQUEST_FIELDS)
                 .responseFields(ApiResponseDocs.withDataFields(RESPONSE_DATA_FIELDS))
                 .build();


### PR DESCRIPTION
## 개요
Refresh Token 갱신 시 디바이스 검증을 추가하고 JPA orphanRemoval 메커니즘으로 토큰 삭제

## 주요 변경사항
### 🔒 보안 강화
- **디바이스 검증 추가**: Refresh Token 갱신 시 요청 device ID와 세션의 device ID를 검증하여 토큰 탈취 방지
- **Header 기반 device ID 전달**: `X-Device-Id` 헤더로 device ID를 전달하도록 변경 (로그인 제외 모든 엔드포인트에서 일관성 유지)

### ♻️ 리팩토링
- RefreshTokenRequest에서 `deviceInfo` 객체 제거, deviceId는 헤더로 분리
- 명시적 `refreshTokenRepository.delete()` 호출을 제거하고 `session.updateRefreshToken(null)`로 통일

### 📝 API 변경사항
```http
POST /api/auth/refresh
Headers:
  X-Device-Id: {deviceId} // 추가
  Content-Type: application/json

Body:
{
  "refreshToken": "...",
  "locationInfo": { // optional
    "latitude": 37.5,
    "longitude": 127.0
  }
}
```

### 🧪 테스트
- AuthControllerTest 업데이트: X-Device-Id 헤더 추가
- RefreshTokenDocs 업데이트: 헤더 파라미터 문서화
- 모든 테스트 통과 확인


## 기술적 배경
### 보안 시나리오
1. Device A에서 로그인 → refreshToken1 발급 → Session(deviceId=A)에 연결
2. 공격자가 Device B에서 refreshToken1을 탈취
3. Device B가 갱신 요청 시 X-Device-Id: B를 전송
4. 서버가 refreshToken1의 Session은 deviceId=A인 것을 확인
5. 디바이스 불일치 감지 → 요청 거부 🚫

### orphanRemoval 통일의 이점
- SQL 실행 순서 보장: OrphanRemovalAction → EntityDeleteAction
- 중복 제거 방지 및 코드 일관성 향상
- Unique constraint 위반 방지