### PR TITLE
[fix] 인증 필터 적용 범위 수정

### DIFF
--- a/src/main/java/app/mockly/domain/auth/controller/AuthController.java
+++ b/src/main/java/app/mockly/domain/auth/controller/AuthController.java
@@ -51,11 +51,13 @@ public class AuthController {
 
     @PostMapping("/logout")
     public ResponseEntity<ApiResponse<Void>> logout(
-            @AuthenticationPrincipal UUID userId,
-            @RequestHeader("Authorization") String authorization,
+            @RequestHeader(value = "Authorization", required = false) String authorization,
             @RequestBody LogoutRequest request
     ) {
-        String accessToken = authorization.substring(7);
+        String accessToken = null;
+        if (authorization != null && authorization.startsWith("Bearer ")) {
+            accessToken = authorization.substring(7);
+        }
         authService.logout(accessToken, request.refreshToken());
         return ResponseEntity.ok(ApiResponse.noContent());
     }

--- a/src/main/java/app/mockly/domain/auth/service/AuthService.java
+++ b/src/main/java/app/mockly/domain/auth/service/AuthService.java
@@ -19,6 +19,7 @@ import app.mockly.global.config.JwtProperties;
 import app.mockly.global.exception.InvalidTokenException;
 import app.mockly.global.exception.ResourceNotFoundException;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.parameters.P;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -171,8 +172,12 @@ public class AuthService {
 
     @Transactional
     public void logout(String accessToken, String refreshToken) {
-        long remainingExpiration = jwtService.getRemainingExpiration(accessToken);
-        tokenBlacklistService.save(accessToken, remainingExpiration);
+        if (accessToken != null) {
+            long remainingExpiration = jwtService.getRemainingExpiration(accessToken);
+            if (remainingExpiration > 0) {
+                tokenBlacklistService.save(accessToken, remainingExpiration);
+            }
+        }
 
         refreshTokenRepository.findByToken(refreshToken)
                 .ifPresent(rt -> {


### PR DESCRIPTION
- Multi FilterChain (public/private) 적용
- logout 시 Authorization Header optional 처리
- 유효하지 않은 Access Token도 로그아웃 허용