### PR TITLE
[feat] AI 모의 면접 API (3)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,524 @@
+# AGENTS.md
+
+This file provides guidance to Codex (Codex.ai/code) when working with code in this repository.
+
+## Codex's Role: Senior Backend Developer Coach
+
+**You are a coaching assistant, NOT a code writer.**
+
+### Teaching, Not Doing
+
+When given a problem, bug report, or feature request, **empower the developer to solve it themselves** rather than implementing it directly.
+
+#### 1. Analyze and Explain (Why, What, How)
+
+**Why (왜)** - Explain the root cause:
+- Why is this problem occurring?
+- What is the underlying technical reason?
+- What design pattern or architecture is involved?
+
+**What (무엇을)** - Define what needs to be done:
+- What specific components need to be changed?
+- What are the acceptance criteria?
+- What are the dependencies and impacts?
+
+**How (어떻게)** - Provide a step-by-step approach:
+- Break down into small, manageable steps
+- Explain each step with technical reasoning
+- Suggest code patterns or examples for reference
+- **Compare alternatives**: 다른 설계 방식과의 차이점, 장단점(trade-offs) 비교
+
+#### 2. Break Down Into Small Units
+
+- **Never try to implement entire features at once**
+- Divide into incremental, testable steps
+- Each step should be independently verifiable
+- Prioritize steps by dependency and importance
+
+#### 3. Code Suggestions, Not Direct Implementation
+
+- Suggest method signatures and structure
+- Explain the logic and flow
+- Provide pseudocode or partial snippets as hints
+- **Do NOT directly write or edit code files unless explicitly requested** with phrases like:
+  - "직접 코드 써줘"
+  - "고쳐줘"
+  - "Write the code"
+  - "Fix this code"
+
+#### 4. Encourage Learning
+
+- Ask clarifying questions to ensure understanding
+- Explain architectural decisions and their implications
+- Reference relevant documentation or best practices
+- Help the developer build intuition for future problems
+
+#### 5. Communication Style
+
+- Be concise and direct
+- No fluff, only essential points
+- Cut to the chase
+
+#### 6. Commit Policy
+
+- Do **not** create commits on behalf of the developer.
+- When changes are ready, recommend:
+  - the exact files that should be included in the commit
+  - a concise commit message
+- The developer will review, stage, and commit changes themselves.
+
+---
+
+## Project Overview
+
+Mockly is an AI-based mock interview platform built with Spring Boot 3.5.7 and Java 21. The application uses OAuth 2.1 with PKCE for Google authentication, JWT-based authorization, and follows a domain-driven design structure.
+
+**Current implementation includes:**
+- User authentication (OAuth 2.1 + Google Social Login)
+- Subscription and payment system (PortOne integration)
+- Interview practice features (in development)
+
+### Core Features
+
+1. **AI Interview Practice** - 24/7 AI-powered 1:1 interview practice with text/voice Q&A and immediate feedback
+2. **Learning Notification System** - Push notifications for building learning habits
+3. **Online Mock Interview Matching** - Real-time video mock interviews (1:1, 1:N, N:M) with AI-based analysis
+4. **Offline Mock Interview Matching** - Map-based nearby meeting recommendations and schedule management
+5. **Expert Matching Platform** - Interview coach/speech instructor profiles with booking and payment
+
+### Technology Stack
+
+- **Spring Boot 3.5.7** with Spring Data JPA, Spring Security, Spring Web
+- **Spring AI 1.0.3** for OpenAI integration and vector store capabilities
+- **PGVector** for vector similarity search with PostgreSQL
+- **OAuth2 Resource Server** for JWT authentication
+- **PostgreSQL** (production) with PGVector extension / **H2** (development/testing)
+- **PortOne v2 SDK** for payment and billing key management
+- **Spring REST Docs** + **restdocs-api-spec** for API documentation
+- **Lombok**, **JUnit 5**, **Spring Security Test**
+
+## Build & Development Commands
+
+### Building the Project
+
+```bash
+# Full clean build (runs tests, generates OpenAPI docs, creates bootJar)
+./gradlew clean build
+
+# Build without tests
+./gradlew build -x test
+
+# Run tests only
+./gradlew test
+
+# Run specific test class
+./gradlew test --tests "app.mockly.domain.auth.controller.AuthControllerTest"
+
+# Run specific test method
+./gradlew test --tests "app.mockly.domain.auth.controller.AuthControllerTest.loginWithGoogleCode"
+```
+
+### Running the Application
+
+```bash
+# Local development (requires .env file)
+./gradlew bootRun
+
+# Docker Compose (dev profile with Swagger UI)
+docker compose up --build
+
+# Docker Compose without rebuild
+docker compose up
+```
+
+**Important**: Always use `./gradlew` (Gradle Wrapper) instead of system `gradle` to ensure consistent build behavior, especially in Docker builds.
+
+### API Documentation
+
+The project uses **Spring REST Docs** + **restdocs-api-spec** to generate OpenAPI 3.0 specs from tests, not annotation-based Swagger.
+
+```bash
+# Generate OpenAPI documentation (automatically runs during build)
+./gradlew openapi3
+
+# Access Swagger UI (dev profile only)
+# http://localhost:8080/swagger-ui.html
+```
+
+Documentation is generated from controller tests in `src/test/java/app/mockly/domain/*/controller/`. The OpenAPI spec is output to `src/main/resources/static/openapi3.yaml`.
+
+**Build Pipeline**: `test` → `openapi3` → `bearerAuthentication` → `bootJar`
+
+The `bearerAuthentication` Gradle task automatically appends JWT security schemas to the generated OpenAPI file.
+
+## Architecture
+
+### Domain Structure
+
+The codebase follows a layered domain-driven architecture:
+
+```
+src/main/java/app/mockly/
+├── domain/
+│   ├── auth/                    # Authentication & Authorization
+│   │   ├── controller/          # REST API endpoints
+│   │   ├── dto/                 # Request/Response DTOs
+│   │   ├── entity/              # JPA entities (User, RefreshToken)
+│   │   ├── repository/          # Spring Data JPA repositories
+│   │   └── service/             # Business logic
+│   ├── payment/                 # Payment & Subscription
+│   │   ├── client/              # PortOne SDK integration
+│   │   ├── controller/          # Payment APIs
+│   │   ├── entity/              # Payment, Invoice, OutboxEvent
+│   │   ├── scheduler/           # Background jobs
+│   │   └── service/             # Payment logic
+│   └── product/                 # Plans & Subscriptions
+└── global/
+    ├── common/                  # Common response wrappers (ApiResponse)
+    ├── config/                  # Configuration classes (Security, JWT)
+    ├── exception/               # Custom exceptions and handlers
+    └── security/                # JWT filters and entry points
+```
+
+### Package Organization Guidelines
+
+When adding new domains, follow this structure:
+- `controller/` - REST API endpoints
+- `service/` - Business logic layer
+- `repository/` - Data access layer (Spring Data JPA)
+- `entity/` - JPA entities
+- `dto/` - Data transfer objects
+- `client/` - External API integrations (optional)
+- `scheduler/` - Background jobs (optional)
+
+Place domain-specific exceptions in `global/exception/` and register in `GlobalExceptionHandler`.
+
+### Authentication Flow
+
+1. **OAuth 2.1 + PKCE**: Client exchanges authorization code for Google ID token
+2. **User Creation/Lookup**: GoogleOAuthService verifies ID token and creates/finds User
+3. **Token Generation**: JwtService generates access token (15min) and refresh token (7 days)
+4. **Refresh Token Rotation**: When refreshing, both access and refresh tokens are rotated
+5. **Multi-Device Limit**: Maximum 2 valid refresh tokens per user (oldest is deleted)
+
+### API Response Format
+
+All API responses use a standardized wrapper (`ApiResponse<T>`):
+
+```json
+{
+  "success": true,
+  "data": { ... },
+  "error": null,
+  "message": null,
+  "timestamp": 1234567890123
+}
+```
+
+For errors:
+```json
+{
+  "success": false,
+  "data": null,
+  "error": "INVALID_TOKEN",
+  "message": "유효하지 않은 토큰입니다",
+  "timestamp": 1234567890123
+}
+```
+
+### Security Configuration
+
+- **Stateless sessions**: JWT-based, no server-side session storage
+- **Public endpoints**: `/api/auth/login/**`, `/api/auth/refresh`, `/api/webhooks/**`, Swagger UI paths
+- **Authenticated endpoints**: `/api/auth/me` and all other routes
+- **JWT Filter**: `JwtAuthenticationFilter` runs before `UsernamePasswordAuthenticationFilter`
+- **Exception Handling**: `CustomAuthenticationEntryPoint` returns standardized error responses
+
+### Database
+
+- **Development**: PostgreSQL 16 (via Docker Compose)
+- **JPA**: Hibernate with `create-drop` DDL strategy in dev
+- **Entities**: Use UUID as primary keys (except static data like Plan), Lombok builders
+- **Profiles**: `dev` profile enables Swagger UI and auto DDL
+
+### Database Strategy
+
+- Use JPA entities with proper relationships
+- H2 for local development and tests
+- PostgreSQL for production
+- Leverage Spring Data JPA repositories for data access
+- Design schema to support domain requirements
+- Use `@Query` with `JOIN FETCH` to avoid N+1 problems
+- Apply `@Transactional(readOnly = true)` for read-only operations
+
+## Testing & Documentation Patterns
+
+### Test Documentation Structure
+
+Controller tests use a reusable docs pattern to reduce verbosity:
+
+```
+src/test/java/app/mockly/
+├── common/
+│   └── ApiResponseDocs.java           # Common response field patterns
+└── domain/auth/controller/
+    ├── AuthControllerTest.java        # Controller integration tests
+    └── docs/
+        ├── AuthMeDocs.java            # Docs for /api/auth/me endpoint
+        ├── LoginWithGoogleCodeDocs.java
+        └── RefreshTokenDocs.java
+```
+
+**Pattern**:
+- Docs classes define `ResourceSnippetParameters` for request/response fields
+- `ApiResponseDocs.withDataFields()` combines common response fields with endpoint-specific data fields
+- `ApiResponseDocs.errorResponse(String)` provides standardized error response documentation
+- Use `resource()` wrapper from `MockMvcRestDocumentationWrapper.document()` instead of plain `document()`
+
+**Example**:
+```java
+// In test
+.andDo(document("auth-me",
+    resource(AuthMeDocs.success())
+))
+
+// Instead of verbose inline field documentation
+```
+
+### Test Document Identifiers
+
+`restdocs-api-spec` merges multiple tests for the same endpoint **alphabetically by document identifier**.
+
+**Best Practice**:
+- Success case identifier should come first alphabetically (e.g., `auth-me` before `auth-me-invalid-token`)
+- Error case docs should omit `summary` and `description` to avoid overriding success case metadata
+- Only document request headers in the success case to prevent conflicts
+
+### Running Tests
+
+Tests use `@SpringBootTest` with real application context and in-memory H2 for isolation:
+
+```java
+@SpringBootTest
+@AutoConfigureMockMvc
+@AutoConfigureRestDocs
+@Transactional  // Rollback after each test
+```
+
+Mock only external dependencies (e.g., `@MockitoBean` for `GoogleOAuthService`, `PortOneService`).
+
+### Testing Strategy
+
+- Write JUnit 5 tests for all service layer logic
+- Use `@SpringBootTest` for integration tests
+- Generate REST API documentation with Spring REST Docs
+- Test OAuth2 flows with Spring Security Test
+- Mock external API calls (PortOne, Google OAuth) in tests to avoid costs
+- Test edge cases and error handling
+
+## Environment Variables
+
+Required environment variables (use `.env` for local development):
+
+```
+POSTGRES_HOST=postgres
+POSTGRES_USER=mockly
+POSTGRES_PASSWORD=<password>
+POSTGRES_DB=mockly
+POSTGRES_PORT=5432
+JWT_SECRET=<secret-key>
+GOOGLE_ANDROID_CLIENT_ID=<google-oauth-client-id>
+PORTONE_API_SECRET=<portone-api-secret>
+PORTONE_WEBHOOK_SECRET=<portone-webhook-secret>
+PORTONE_STORE_ID=<portone-store-id>
+PORTONE_CHANNEL_KEY=<portone-channel-key>
+```
+
+## Key Implementation Details
+
+### Refresh Token Rotation
+
+When a refresh token is used:
+1. Old refresh token is validated and deleted
+2. New access token AND new refresh token are issued
+3. Maximum 2 active refresh tokens per user (oldest deleted if exceeded)
+
+This implements token rotation for security while supporting multi-device login.
+
+### JWT Configuration
+
+- Access Token: 15 minutes (900000 ms)
+- Refresh Token: 7 days (604800000 ms) - planned to extend to 30 days
+- Algorithm: HS512
+- Stored in: `JwtProperties` class from `application.yaml`
+
+### Payment System Architecture
+
+- **Transactional Outbox Pattern**: PortOne schedule creation requests are persisted to DB first, then processed asynchronously to ensure at-least-once delivery
+- **Webhook Verification**: PortOne webhook signature validation prevents unauthorized requests
+- **Idempotency**: DB-based duplicate prevention + 409 error handling for PortOne schedule creation
+- **Scheduled Jobs**: PAST_DUE expiration (daily 3 AM), Outbox event retry (every 60s)
+
+### Docker Build Behavior
+
+The `Dockerfile` uses multi-stage build:
+1. Build stage: Runs `./gradlew clean build` which executes tests and generates docs
+2. Runtime stage: Uses OpenJDK 21 slim image with built JAR
+
+**Critical**: The build must run tests to generate REST Docs snippets in `build/generated-snippets/` before `openapi3` task can generate the OpenAPI spec.
+
+## Common Patterns
+
+### Creating New Endpoints
+
+1. Add controller method with Spring REST Docs test
+2. Create docs class in `src/test/java/app/mockly/domain/*/controller/docs/`
+3. Define request/response fields using `ApiResponseDocs` helpers
+4. Run `./gradlew clean build` to regenerate OpenAPI spec
+5. Verify in Swagger UI at `http://localhost:8080/swagger-ui.html` (dev profile)
+
+### Adding New Domains
+
+Follow the existing structure:
+```
+domain/<domain-name>/
+├── controller/
+├── dto/
+├── entity/
+├── repository/
+└── service/
+```
+
+Place domain-specific exceptions in `global/exception/` and register in `GlobalExceptionHandler`.
+
+## Commit Message Convention
+
+**커밋은 항상 사용자가 직접 한다. Codex는 커밋 메시지를 추천만 하고, 절대 직접 커밋하지 않는다.**
+
+커밋 메시지 추천 시 subject와 description을 함께 제안한다.
+
+This project uses Korean commit messages with the following format:
+
+```
+[type] 간결한 커밋 메시지 (50자 이내)
+
+- 변경 내용 설명 (선택 사항)
+- 설계 결정이나 이유가 있으면 포함
+```
+
+### Commit Types
+
+- `feat` - 새로운 기능 추가
+- `fix` - 버그 수정
+- `refactor` - 리팩터링 (기능 변화 없음)
+- `test` - 테스트 코드 추가/수정
+- `docs` - 문서 수정
+- `style` - 코드 스타일 수정 (포맷팅)
+- `chore` - 빌드/설정 관련
+- `perf` - 성능 개선
+- `ci` - CI/CD 설정
+- `build` - 빌드 시스템 변경
+
+### Examples
+
+```
+[feat] 세션 상세 조회 API 구현
+
+- GET /api/interviews/:sessionId 엔드포인트 추가
+- 세션 메타정보 및 전체 대화 내역(messages) 반환
+- 컨트롤러 테스트 및 REST Docs 추가
+```
+
+## Code Review Standards
+
+When reviewing backend code, focus on:
+
+### 1. Code Quality
+
+- Single Responsibility Principle (SRP)
+- Consistent naming conventions
+- DRY principle (avoid duplication)
+- Appropriate abstraction levels
+
+### 2. API Design
+
+- RESTful conventions
+- Proper HTTP methods and status codes
+- API versioning strategy
+- Pagination implementation
+
+### 3. Security
+
+- SQL injection prevention (use JPA/parameterized queries)
+- OAuth 2.1 + PKCE implementation correctness
+- JWT validation and refresh token handling
+- Input validation (Bean Validation)
+- CORS configuration
+- No sensitive data (API keys, tokens, billing keys) in logs or responses
+- Webhook signature verification for external integrations
+
+### 4. Database
+
+- Query optimization (avoid N+1 problems with JOIN FETCH)
+- Proper indexing
+- Transaction management (`@Transactional` scope)
+- Data integrity constraints
+- Use appropriate primary key types (UUID for user data, Integer for static data)
+
+### 5. Error Handling
+
+- Proper exception handling with try-catch
+- Comprehensive error logging
+- User-friendly error messages (hide internal details)
+- Transaction rollback considerations (don't mark entities as failed then throw exception - state won't persist)
+
+### 6. Performance
+
+- Database query performance
+- Caching strategy (consider Redis integration)
+- Async processing where appropriate (Outbox pattern for external API calls)
+- Connection pooling
+- Client timeout configuration for external API calls
+
+### 7. Testing
+
+- Unit test coverage for services
+- Integration tests for endpoints
+- Edge case handling
+- Mock external dependencies (PortOne, Google OAuth)
+- Test security flows
+
+## Important Development Practices
+
+- Always use the Gradle wrapper (`./gradlew`) instead of global Gradle
+- Run tests before committing (`./gradlew test`)
+- Use Lombok annotations to reduce boilerplate
+- Leverage Spring Boot DevTools for rapid development
+- Document REST APIs with Spring REST Docs
+- Keep business logic in service layer, not controllers
+- Use DTOs for API requests/responses, not entities directly
+- Controller에서 직접 사용하는 request/response DTO는 HTTP 동사를 접두사로 사용: `GetXXXRequest`, `GetXXXResponse`, `CreateXXXRequest`, `CreateXXXResponse`, `DeleteXXXRequest` 등
+- Mock external API calls in tests
+- Never log sensitive information (billing keys, tokens, passwords)
+- Use JSON libraries (ObjectMapper) for JSON construction, never String.format
+- Apply proper transaction boundaries - don't modify entities then throw exceptions in same transaction
+- Use idempotency keys or DB constraints to prevent duplicate operations
+
+## Commit Message Recommendations
+
+When a task reaches a commit-worthy checkpoint, include a recommended commit message in the final response.
+
+- Match the recent repository commit style.
+- Use this default format:
+
+```text
+<type>: <short summary>
+
+- <change 1>
+- <change 2>
+- <test or verification>
+```
+
+- Choose `feat`, `fix`, `refactor`, `test`, `docs`, or `chore` based on the actual change.
+- If the work contains multiple logical commit units, suggest splitting the commit and provide one message per unit.
+- Do not create the commit unless explicitly asked.

--- a/build.gradle
+++ b/build.gradle
@@ -42,6 +42,7 @@ openapi3 {
 }
 
 dependencies {
+	implementation 'org.springframework.boot:spring-boot-starter-actuator'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 	implementation 'org.springframework.boot:spring-boot-starter-oauth2-resource-server'
@@ -68,6 +69,7 @@ dependencies {
     developmentOnly 'me.paulschwarz:spring-dotenv:4.0.0'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 	runtimeOnly 'com.h2database:h2'
+	runtimeOnly 'io.micrometer:micrometer-registry-prometheus'
 	runtimeOnly 'org.postgresql:postgresql'
 	annotationProcessor 'org.projectlombok:lombok'
 
@@ -88,7 +90,18 @@ dependencyManagement {
 
 tasks.named('test') {
 	outputs.dir snippetsDir
-	useJUnitPlatform()
+	useJUnitPlatform {
+		excludeTags 'latency'
+	}
+}
+
+tasks.register('latencyTest', Test) {
+	useJUnitPlatform {
+		includeTags 'latency'
+	}
+	testLogging {
+		showStandardStreams = true
+	}
 }
 
 tasks.named('asciidoctor') {

--- a/build.gradle
+++ b/build.gradle
@@ -29,7 +29,7 @@ repositories {
 
 ext {
 	set('snippetsDir', file("build/generated-snippets"))
-	set('springAiVersion', "1.0.3")
+	set('springAiVersion', "1.1.4")
 }
 
 openapi3 {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -54,7 +54,8 @@ services:
       mockly-redis:
         condition: service_healthy
     environment:
-      SPRING_PROFILES_ACTIVE: dev
+      SPRING_PROFILES_ACTIVE: ${SPRING_PROFILES_ACTIVE:-dev}
+      HIKARI_MAX_POOL_SIZE: ${HIKARI_MAX_POOL_SIZE:-10}
       POSTGRES_HOST: mockly-postgres
       POSTGRES_USER: ${POSTGRES_USER}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
@@ -72,6 +73,8 @@ services:
       OPENAI_API_KEY: ${OPENAI_API_KEY}
     ports:
       - "8080:8080"
+    volumes:
+      - ./loadtest-fixtures.json:/app/loadtest-fixtures.json
     networks:
       - mockly-network
 
@@ -79,6 +82,9 @@ services:
     image: prom/prometheus:latest
     container_name: mockly-prometheus
     restart: always
+    command:
+      - '--config.file=/etc/prometheus/prometheus.yml'
+      - '--web.enable-remote-write-receiver'
     volumes:
       - ./monitoring/prometheus.yml:/etc/prometheus/prometheus.yml
       - prometheus_data:/prometheus

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -75,9 +75,41 @@ services:
     networks:
       - mockly-network
 
+  prometheus:
+    image: prom/prometheus:latest
+    container_name: mockly-prometheus
+    restart: always
+    volumes:
+      - ./monitoring/prometheus.yml:/etc/prometheus/prometheus.yml
+      - prometheus_data:/prometheus
+    ports:
+      - "9090:9090"
+    networks:
+      - mockly-network
+    depends_on:
+      - app
+
+  grafana:
+    image: grafana/grafana:latest
+    container_name: mockly-grafana
+    restart: always
+    environment:
+      GF_SECURITY_ADMIN_USER: admin
+      GF_SECURITY_ADMIN_PASSWORD: admin
+    volumes:
+      - grafana_data:/var/lib/grafana
+    ports:
+      - "3000:3000"
+    networks:
+      - mockly-network
+    depends_on:
+      - prometheus
+
 volumes:
   postgres_data:
   redis_data:
+  prometheus_data:
+  grafana_data:
 
 networks:
   mockly-network:

--- a/loadtest/connection-pool-exhaustion.js
+++ b/loadtest/connection-pool-exhaustion.js
@@ -1,0 +1,208 @@
+/*
+ * HikariCP 커넥션 풀 고갈 재현용 k6 부하 테스트
+ *
+ * 실행 전 준비:
+ *   1. Spring Boot 애플리케이션을 http://localhost:8080 에서 실행합니다.
+ *   2. 리포지토리 루트에 loadtest-fixtures.json 파일이 있어야 합니다.
+ *   3. k6는 handleSummary()에서 디렉터리를 만들 수 없으므로 결과 디렉터리를 먼저 만듭니다.
+ *
+ * 실행:
+ *   mkdir -p results
+ *   k6 run loadtest/connection-pool-exhaustion.js
+ *
+ * 선택 환경 변수:
+ *   BASE_URL=http://localhost:8080
+ *   RESULT_PATH=results/scenario-1.json
+ */
+
+import http from 'k6/http';
+import exec from 'k6/execution';
+import { check, sleep } from 'k6';
+
+const BASE_URL = __ENV.BASE_URL || 'http://localhost:8080';
+const RESULT_PATH = __ENV.RESULT_PATH || 'results/scenario-1.json';
+const EXPECTED_USER_COUNT = 30;
+const ANSWER_BODY = JSON.stringify({ content: '테스트 답변입니다.' });
+
+const fixtures = JSON.parse(open('../loadtest-fixtures.json'));
+
+validateFixtures(fixtures);
+
+export const options = {
+  scenarios: {
+    attacker: {
+      executor: 'ramping-vus',
+      exec: 'attacker',
+      startVUs: 0,
+      stages: [
+        { duration: '1m', target: 10 },
+        { duration: '2m', target: 10 },
+        { duration: '1m', target: 20 },
+        { duration: '2m', target: 20 },
+        { duration: '1m', target: 30 },
+        { duration: '2m', target: 30 },
+        { duration: '1m', target: 45 },
+        { duration: '2m', target: 45 },
+        { duration: '1m', target: 60 },
+        { duration: '2m', target: 60 },
+      ],
+      gracefulRampDown: '0s',
+    },
+    victim: {
+      executor: 'constant-vus',
+      exec: 'victim',
+      vus: 5,
+      duration: '15m',
+    },
+  },
+  thresholds: {
+    // submit-answer: 정상 시 ~10s(mock). p95 12s 초과 = 커넥션 대기 발생 증거
+    'http_req_duration{endpoint:submit-answer}': ['p(95)<12000'],
+    // submit-answer: 커넥션 획득 실패(connection-timeout 5s) 시 500 에러
+    'http_req_failed{endpoint:submit-answer}': ['rate<0.05'],
+    // db-ping: SELECT 1이 500ms 초과 = 풀 고갈로 무관한 API까지 피해
+    'http_req_duration{endpoint:db-ping}': ['p(95)<500'],
+    'http_req_failed{endpoint:db-ping}': ['rate<0.05'],
+  },
+};
+
+export function attacker() {
+  // exec.scenario.iterationInTest: attacker 시나리오 내 모든 VU 통틀어 0부터 단조 증가하는 고유 번호.
+  // 이걸로 user/session 인덱스를 매핑해서 같은 세션을 절대 두 번 사용하지 않게 한다.
+  const globalIter = exec.scenario.iterationInTest;
+  const sessionsPerUser = fixtures[0].sessionIds.length;
+  const userIndex = Math.floor(globalIter / sessionsPerUser) % fixtures.length;
+  const sessionIndex = globalIter % sessionsPerUser;
+
+  const user = fixtures[userIndex];
+  const sessionId = user.sessionIds[sessionIndex];
+
+  // user 한 명당 sessionsPerUser 개 다 쓰면 다음 user로 넘어가는데,
+  // user 30명 × 300 세션 = 9,000개를 다 쓰면 더 이상 새 세션이 없다.
+  const totalSessions = fixtures.length * sessionsPerUser;
+  if (globalIter >= totalSessions) {
+    sleep(5);
+    return;
+  }
+
+  const response = http.post(
+    `${BASE_URL}/api/interviews/${sessionId}/answer`,
+    ANSWER_BODY,
+    {
+      headers: {
+        Authorization: `Bearer ${user.token}`,
+        'Content-Type': 'application/json',
+      },
+      tags: { endpoint: 'submit-answer', scenario: exec.scenario.name },
+      timeout: '30s',
+    },
+  );
+
+  const ok = check(response, {
+    'submit-answer 상태 코드가 2xx이다': (res) => res.status >= 200 && res.status < 300,
+  });
+
+  if (!ok) {
+    console.error(`[submit-answer] ${response.status} — sessionId=${sessionId} body=${response.body?.substring(0, 200)}`);
+  }
+}
+
+export function victim() {
+  const response = http.get(`${BASE_URL}/api/loadtest/db-ping`, {
+    tags: { endpoint: 'db-ping', scenario: exec.scenario.name },
+    timeout: '10s',
+  });
+
+  check(response, {
+    'db-ping 상태 코드가 200이다': (res) => res.status === 200,
+  });
+
+  sleep(1);
+}
+
+export function handleSummary(data) {
+  return {
+    stdout: textSummary(data),
+    [RESULT_PATH]: JSON.stringify(data, null, 2),
+  };
+}
+
+// 요약 출력용 헬퍼
+function textSummary(data) {
+  const m = data.metrics;
+  const lines = [
+    '',
+    '=== k6 summary ===',
+    '',
+    '[ submit-answer ]',
+    `  duration ...: ${formatTrend(m['http_req_duration{endpoint:submit-answer}'])}`,
+    `  failed .....: ${formatRate(m['http_req_failed{endpoint:submit-answer}'])}`,
+    `  reqs .......: ${formatCount(m['http_reqs{endpoint:submit-answer}'])}`,
+    '',
+    '[ db-ping ]',
+    `  duration ...: ${formatTrend(m['http_req_duration{endpoint:db-ping}'])}`,
+    `  failed .....: ${formatRate(m['http_req_failed{endpoint:db-ping}'])}`,
+    `  reqs .......: ${formatCount(m['http_reqs{endpoint:db-ping}'])}`,
+    '',
+    '[ overall ]',
+    `  checks .....: ${formatRate(m.checks)}`,
+    `  vus_max ....: ${formatGauge(m.vus_max)}`,
+    '',
+  ];
+  return `${lines.join('\n')}\n`;
+}
+
+function formatRate(metric) {
+  if (!metric || !metric.values) return 'n/a';
+  const { rate = 0, passes = 0, fails = 0 } = metric.values;
+  return `${(rate * 100).toFixed(2)}% (${passes} / ${passes + fails})`;
+}
+
+function formatCount(metric) {
+  if (!metric || !metric.values) return 'n/a';
+  return String(metric.values.count ?? 0);
+}
+
+function formatTrend(metric) {
+  if (!metric || !metric.values) return 'n/a';
+  const v = metric.values;
+  return `avg=${formatMs(v.avg)} min=${formatMs(v.min)} med=${formatMs(v.med)} p(95)=${formatMs(v['p(95)'])} max=${formatMs(v.max)}`;
+}
+
+function formatGauge(metric) {
+  if (!metric || !metric.values) return 'n/a';
+  return String(metric.values.value ?? metric.values.max ?? 'n/a');
+}
+
+function formatMs(value) {
+  if (value === undefined || value === null || Number.isNaN(value)) return 'n/a';
+  return `${Number(value).toFixed(2)}ms`;
+}
+
+function validateFixtures(value) {
+  if (!Array.isArray(value) || value.length === 0) {
+    throw new Error('fixtures는 하나 이상의 사용자를 담은 배열이어야 합니다.');
+  }
+
+  if (value.length !== EXPECTED_USER_COUNT) {
+    throw new Error(`fixtures는 정확히 ${EXPECTED_USER_COUNT}명의 사용자를 담아야 합니다. 현재: ${value.length}명`);
+  }
+
+  for (const [index, user] of value.entries()) {
+    if (!user || typeof user !== 'object') {
+      throw new Error(`fixtures[${index}] 항목은 객체여야 합니다.`);
+    }
+
+    if (!user.userId || typeof user.userId !== 'string') {
+      throw new Error(`fixtures[${index}].userId가 비어 있거나 문자열이 아닙니다.`);
+    }
+
+    if (!user.token || typeof user.token !== 'string') {
+      throw new Error(`fixtures[${index}].token이 비어 있거나 문자열이 아닙니다.`);
+    }
+
+    if (!Array.isArray(user.sessionIds) || user.sessionIds.length === 0) {
+      throw new Error(`fixtures[${index}].sessionIds는 하나 이상의 sessionId를 담은 배열이어야 합니다.`);
+    }
+  }
+}

--- a/loadtest/scenario-c-async-feedback.js
+++ b/loadtest/scenario-c-async-feedback.js
@@ -1,0 +1,219 @@
+/*
+ * 시나리오 C: 피드백 비동기 처리 검증용 k6 부하 테스트
+ *
+ * 목적:
+ *   submitAnswer()의 AI 호출을 트랜잭션 밖으로 분리한 후
+ *   POST /answer가 커넥션 풀 고갈 없이 빠르게 응답하는지 검증한다.
+ *
+ *   시나리오 A (pool=10, 동기): submit-answer 28% 실패, db-ping p95=5,013ms
+ *   시나리오 C (pool=10, 비동기): 0% 실패, p95 < 500ms 예상
+ *
+ * 실행 전 준비:
+ *   1. Spring Boot 애플리케이션을 http://localhost:8080 에서 실행합니다.
+ *   2. 리포지토리 루트에 loadtest-fixtures.json 파일이 있어야 합니다.
+ *      (기존 fixture 재사용 가능 — 세션당 1문항 구성)
+ *   3. k6는 handleSummary()에서 디렉터리를 만들 수 없으므로 결과 디렉터리를 먼저 만듭니다.
+ *
+ * 실행:
+ *   mkdir -p results
+ *   k6 run loadtest/scenario-c-async-feedback.js
+ *
+ * 선택 환경 변수:
+ *   BASE_URL=http://localhost:8080
+ *   RESULT_PATH=results/scenario-c.json
+ */
+
+import http from 'k6/http';
+import exec from 'k6/execution';
+import { check, sleep } from 'k6';
+
+const BASE_URL = __ENV.BASE_URL || 'http://localhost:8080';
+const RESULT_PATH = __ENV.RESULT_PATH || 'results/scenario-c.json';
+const EXPECTED_USER_COUNT = 30;
+const ANSWER_BODY = JSON.stringify({ content: '테스트 답변입니다.' });
+
+const fixtures = JSON.parse(open('../loadtest-fixtures.json'));
+
+validateFixtures(fixtures);
+
+export const options = {
+  scenarios: {
+    attacker: {
+      executor: 'ramping-vus',
+      exec: 'attacker',
+      startVUs: 0,
+      stages: [
+        { duration: '1m', target: 10 },
+        { duration: '2m', target: 10 },
+        { duration: '1m', target: 20 },
+        { duration: '2m', target: 20 },
+        { duration: '1m', target: 30 },
+        { duration: '2m', target: 30 },
+        { duration: '1m', target: 45 },
+        { duration: '2m', target: 45 },
+        { duration: '1m', target: 60 },
+        { duration: '2m', target: 60 },
+      ],
+      gracefulRampDown: '0s',
+    },
+    victim: {
+      executor: 'constant-vus',
+      exec: 'victim',
+      vus: 5,
+      duration: '15m',
+    },
+  },
+  thresholds: {
+    // 비동기화 후 AI 호출이 트랜잭션 밖에서 실행되므로 p95 500ms 이내여야 한다
+    'http_req_duration{endpoint:submit-answer}': ['p(95)<500'],
+    'http_req_failed{endpoint:submit-answer}': ['rate<0.01'],
+    // db-ping: 커넥션 풀 고갈이 없으면 SELECT 1은 항상 500ms 이내
+    'http_req_duration{endpoint:db-ping}': ['p(95)<500'],
+    'http_req_failed{endpoint:db-ping}': ['rate<0.01'],
+  },
+};
+
+export function attacker() {
+  const globalIter = exec.scenario.iterationInTest;
+  const sessionsPerUser = fixtures[0].sessionIds.length;
+  const userIndex = Math.floor(globalIter / sessionsPerUser) % fixtures.length;
+  const sessionIndex = globalIter % sessionsPerUser;
+
+  const user = fixtures[userIndex];
+  const sessionId = user.sessionIds[sessionIndex];
+
+  const totalSessions = fixtures.length * sessionsPerUser;
+  if (globalIter >= totalSessions) {
+    sleep(5);
+    return;
+  }
+
+  const response = http.post(
+    `${BASE_URL}/api/interviews/${sessionId}/answer`,
+    ANSWER_BODY,
+    {
+      headers: {
+        Authorization: `Bearer ${user.token}`,
+        'Content-Type': 'application/json',
+      },
+      tags: { endpoint: 'submit-answer', scenario: exec.scenario.name },
+      timeout: '5s', // 비동기화 후 5s 내 응답이 없으면 실패로 간주
+    },
+  );
+
+  const ok = check(response, {
+    'submit-answer 상태 코드가 2xx이다': (res) => res.status >= 200 && res.status < 300,
+    'submit-answer 피드백 대기 또는 진행 중이다': (res) => {
+      try {
+        const body = JSON.parse(res.body);
+        const status = body?.data?.sessionStatus;
+        return status === 'FEEDBACK_PENDING' || status === 'IN_PROGRESS';
+      } catch (_) {
+        return false;
+      }
+    },
+  });
+
+  if (!ok) {
+    console.error(`[submit-answer] ${response.status} — sessionId=${sessionId} body=${response.body?.substring(0, 200)}`);
+  }
+}
+
+export function victim() {
+  const response = http.get(`${BASE_URL}/api/loadtest/db-ping`, {
+    tags: { endpoint: 'db-ping', scenario: exec.scenario.name },
+    timeout: '10s',
+  });
+
+  check(response, {
+    'db-ping 상태 코드가 200이다': (res) => res.status === 200,
+  });
+
+  sleep(1);
+}
+
+export function handleSummary(data) {
+  return {
+    stdout: textSummary(data),
+    [RESULT_PATH]: JSON.stringify(data, null, 2),
+  };
+}
+
+function textSummary(data) {
+  const m = data.metrics;
+  const lines = [
+    '',
+    '=== k6 summary (Scenario C: 비동기 피드백) ===',
+    '',
+    '[ submit-answer ]',
+    `  duration ...: ${formatTrend(m['http_req_duration{endpoint:submit-answer}'])}`,
+    `  failed .....: ${formatRate(m['http_req_failed{endpoint:submit-answer}'])}`,
+    `  reqs .......: ${formatCount(m['http_reqs{endpoint:submit-answer}'])}`,
+    '',
+    '[ db-ping ]',
+    `  duration ...: ${formatTrend(m['http_req_duration{endpoint:db-ping}'])}`,
+    `  failed .....: ${formatRate(m['http_req_failed{endpoint:db-ping}'])}`,
+    `  reqs .......: ${formatCount(m['http_reqs{endpoint:db-ping}'])}`,
+    '',
+    '[ overall ]',
+    `  checks .....: ${formatRate(m.checks)}`,
+    `  vus_max ....: ${formatGauge(m.vus_max)}`,
+    '',
+  ];
+  return `${lines.join('\n')}\n`;
+}
+
+function formatRate(metric) {
+  if (!metric || !metric.values) return 'n/a';
+  const { rate = 0, passes = 0, fails = 0 } = metric.values;
+  return `${(rate * 100).toFixed(2)}% (${passes} / ${passes + fails})`;
+}
+
+function formatCount(metric) {
+  if (!metric || !metric.values) return 'n/a';
+  return String(metric.values.count ?? 0);
+}
+
+function formatTrend(metric) {
+  if (!metric || !metric.values) return 'n/a';
+  const v = metric.values;
+  return `avg=${formatMs(v.avg)} min=${formatMs(v.min)} med=${formatMs(v.med)} p(95)=${formatMs(v['p(95)'])} max=${formatMs(v.max)}`;
+}
+
+function formatGauge(metric) {
+  if (!metric || !metric.values) return 'n/a';
+  return String(metric.values.value ?? metric.values.max ?? 'n/a');
+}
+
+function formatMs(value) {
+  if (value === undefined || value === null || Number.isNaN(value)) return 'n/a';
+  return `${Number(value).toFixed(2)}ms`;
+}
+
+function validateFixtures(value) {
+  if (!Array.isArray(value) || value.length === 0) {
+    throw new Error('fixtures는 하나 이상의 사용자를 담은 배열이어야 합니다.');
+  }
+
+  if (value.length !== EXPECTED_USER_COUNT) {
+    throw new Error(`fixtures는 정확히 ${EXPECTED_USER_COUNT}명의 사용자를 담아야 합니다. 현재: ${value.length}명`);
+  }
+
+  for (const [index, user] of value.entries()) {
+    if (!user || typeof user !== 'object') {
+      throw new Error(`fixtures[${index}] 항목은 객체여야 합니다.`);
+    }
+
+    if (!user.userId || typeof user.userId !== 'string') {
+      throw new Error(`fixtures[${index}].userId가 비어 있거나 문자열이 아닙니다.`);
+    }
+
+    if (!user.token || typeof user.token !== 'string') {
+      throw new Error(`fixtures[${index}].token이 비어 있거나 문자열이 아닙니다.`);
+    }
+
+    if (!Array.isArray(user.sessionIds) || user.sessionIds.length === 0) {
+      throw new Error(`fixtures[${index}].sessionIds는 하나 이상의 sessionId를 담은 배열이어야 합니다.`);
+    }
+  }
+}

--- a/monitoring/prometheus.yml
+++ b/monitoring/prometheus.yml
@@ -1,0 +1,8 @@
+global:
+  scrape_interval: 15s
+
+scrape_configs:
+  - job_name: mockly
+    metrics_path: /actuator/prometheus
+    static_configs:
+      - targets: [ 'app:8080' ]

--- a/monitoring/prometheus.yml
+++ b/monitoring/prometheus.yml
@@ -1,5 +1,5 @@
 global:
-  scrape_interval: 15s
+  scrape_interval: 30s
 
 scrape_configs:
   - job_name: mockly

--- a/src/main/java/app/mockly/domain/interview/controller/InterviewController.java
+++ b/src/main/java/app/mockly/domain/interview/controller/InterviewController.java
@@ -150,6 +150,15 @@ public class InterviewController {
         return ResponseEntity.ok(ApiResponse.success(response));
     }
 
+    @PostMapping("/{sessionId}/feedback/retry")
+    public ResponseEntity<ApiResponse<GetFeedbackResponse>> retryFeedback(
+            @AuthenticationPrincipal UUID userId,
+            @PathVariable UUID sessionId
+    ) {
+        GetFeedbackResponse response = interviewService.retryFeedback(userId, sessionId);
+        return ResponseEntity.status(HttpStatus.ACCEPTED).body(ApiResponse.success(response));
+    }
+
     @PatchMapping("/{sessionId}/abandon")
     public ResponseEntity<ApiResponse<Void>> abandonSession(
             @AuthenticationPrincipal UUID userId,

--- a/src/main/java/app/mockly/domain/interview/controller/InterviewController.java
+++ b/src/main/java/app/mockly/domain/interview/controller/InterviewController.java
@@ -3,6 +3,8 @@ package app.mockly.domain.interview.controller;
 import app.mockly.domain.interview.dto.request.CreateInterviewRequest;
 import app.mockly.domain.interview.dto.request.SubmitAnswerRequest;
 import app.mockly.domain.interview.dto.response.CreateInterviewResponse;
+import app.mockly.domain.interview.dto.response.FeedbackDto;
+import app.mockly.domain.interview.dto.response.GetQuotaResponse;
 import app.mockly.domain.interview.dto.response.GetSessionDetailResponse;
 import app.mockly.domain.interview.dto.response.GetSessionListResponse;
 import app.mockly.domain.interview.dto.response.SubmitAnswerResponse;
@@ -33,6 +35,14 @@ import java.util.UUID;
 public class InterviewController {
 
     private final InterviewService interviewService;
+
+    @GetMapping("/quota")
+    public ResponseEntity<ApiResponse<GetQuotaResponse>> getQuota(
+            @AuthenticationPrincipal UUID userId
+    ) {
+        GetQuotaResponse response = interviewService.getQuota(userId);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
 
     @PostMapping
     public ResponseEntity<ApiResponse<CreateInterviewResponse>> createSession(
@@ -112,6 +122,15 @@ public class InterviewController {
             @RequestBody @Valid SubmitAnswerRequest request
     ) {
         SubmitAnswerResponse response = interviewService.submitAnswer(userId, sessionId, request);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    @GetMapping("/{sessionId}/feedback")
+    public ResponseEntity<ApiResponse<FeedbackDto>> getFeedback(
+            @AuthenticationPrincipal UUID userId,
+            @PathVariable UUID sessionId
+    ) {
+        FeedbackDto response = interviewService.getFeedback(userId, sessionId);
         return ResponseEntity.ok(ApiResponse.success(response));
     }
 

--- a/src/main/java/app/mockly/domain/interview/controller/InterviewController.java
+++ b/src/main/java/app/mockly/domain/interview/controller/InterviewController.java
@@ -114,4 +114,13 @@ public class InterviewController {
         SubmitAnswerResponse response = interviewService.submitAnswer(userId, sessionId, request);
         return ResponseEntity.ok(ApiResponse.success(response));
     }
+
+    @PatchMapping("/{sessionId}/abandon")
+    public ResponseEntity<ApiResponse<Void>> abandonSession(
+            @AuthenticationPrincipal UUID userId,
+            @PathVariable UUID sessionId
+    ) {
+        interviewService.abandonSession(userId, sessionId);
+        return ResponseEntity.ok(ApiResponse.noContent());
+    }
 }

--- a/src/main/java/app/mockly/domain/interview/controller/InterviewController.java
+++ b/src/main/java/app/mockly/domain/interview/controller/InterviewController.java
@@ -1,5 +1,6 @@
 package app.mockly.domain.interview.controller;
 
+import app.mockly.domain.interview.dto.QuestionStream;
 import app.mockly.domain.interview.dto.request.CreateInterviewRequest;
 import app.mockly.domain.interview.dto.request.SubmitAnswerRequest;
 import app.mockly.domain.interview.dto.response.CreateInterviewResponse;
@@ -78,9 +79,10 @@ public class InterviewController {
     ) {
         SseEmitter emitter = new SseEmitter(60_000L);
         StringBuilder fullText = new StringBuilder();
-        int questionNumber = interviewService.getCurrentQuestionNumber(sessionId, userId);
+        QuestionStream qs = interviewService.getQuestionStream(sessionId, userId);
+        int questionNumber = qs.questionNumber();
 
-        interviewService.prepareQuestion(sessionId, userId)
+        qs.tokens()
             .subscribe(
                 token -> {
                     fullText.append(token);

--- a/src/main/java/app/mockly/domain/interview/controller/InterviewController.java
+++ b/src/main/java/app/mockly/domain/interview/controller/InterviewController.java
@@ -15,11 +15,14 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.codec.ServerSentEvent;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+import reactor.core.publisher.Flux;
 
 import java.io.IOException;
+import java.time.Duration;
 import java.util.Map;
 import java.util.UUID;
 

--- a/src/main/java/app/mockly/domain/interview/controller/InterviewController.java
+++ b/src/main/java/app/mockly/domain/interview/controller/InterviewController.java
@@ -127,8 +127,8 @@ public class InterviewController {
             @AuthenticationPrincipal UUID userId,
             @PathVariable UUID sessionId
     ) {
-        SseEmitter emitter = feedbackSseManager.connect(sessionId, 60_000L);
         FeedbackStatusInfo statusInfo = interviewService.getFeedbackStatusInfo(userId, sessionId);
+        SseEmitter emitter = feedbackSseManager.connect(sessionId, 60_000L);
         FeedbackStatus status = statusInfo.feedbackStatus();
         if (status == FeedbackStatus.COMPLETED || status == FeedbackStatus.FAILED) { // SSE 연결 전 이미 피드백 생성이 끝난 경우
             feedbackSseManager.send(sessionId, status, statusInfo.failReason());

--- a/src/main/java/app/mockly/domain/interview/controller/InterviewController.java
+++ b/src/main/java/app/mockly/domain/interview/controller/InterviewController.java
@@ -3,13 +3,10 @@ package app.mockly.domain.interview.controller;
 import app.mockly.domain.interview.dto.QuestionStream;
 import app.mockly.domain.interview.dto.request.CreateInterviewRequest;
 import app.mockly.domain.interview.dto.request.SubmitAnswerRequest;
-import app.mockly.domain.interview.dto.response.CreateInterviewResponse;
-import app.mockly.domain.interview.dto.response.FeedbackDto;
-import app.mockly.domain.interview.dto.response.GetQuotaResponse;
-import app.mockly.domain.interview.dto.response.GetSessionDetailResponse;
-import app.mockly.domain.interview.dto.response.GetSessionListResponse;
-import app.mockly.domain.interview.dto.response.SubmitAnswerResponse;
+import app.mockly.domain.interview.dto.response.*;
+import app.mockly.domain.interview.entity.FeedbackStatus;
 import app.mockly.domain.interview.entity.InterviewSessionStatus;
+import app.mockly.domain.interview.service.FeedbackSseManager;
 import app.mockly.domain.interview.service.InterviewService;
 import app.mockly.global.common.ApiResponse;
 import jakarta.validation.Valid;
@@ -33,6 +30,7 @@ import java.util.UUID;
 public class InterviewController {
 
     private final InterviewService interviewService;
+    private final FeedbackSseManager feedbackSseManager;
 
     @GetMapping("/quota")
     public ResponseEntity<ApiResponse<GetQuotaResponse>> getQuota(
@@ -124,12 +122,31 @@ public class InterviewController {
         return ResponseEntity.ok(ApiResponse.success(response));
     }
 
-    @GetMapping("/{sessionId}/feedback")
-    public ResponseEntity<ApiResponse<FeedbackDto>> getFeedback(
+    @GetMapping(value = "/{sessionId}/feedback/events", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
+    public SseEmitter feedbackEvents(
             @AuthenticationPrincipal UUID userId,
             @PathVariable UUID sessionId
     ) {
-        FeedbackDto response = interviewService.getFeedback(userId, sessionId);
+        SseEmitter emitter = feedbackSseManager.connect(sessionId, 60_000L);
+        FeedbackStatusInfo statusInfo = interviewService.getFeedbackStatusInfo(userId, sessionId);
+        FeedbackStatus status = statusInfo.feedbackStatus();
+        if (status == FeedbackStatus.COMPLETED || status == FeedbackStatus.FAILED) { // SSE 연결 전 이미 피드백 생성이 끝난 경우
+            feedbackSseManager.send(sessionId, status, statusInfo.failReason());
+            feedbackSseManager.complete(sessionId);
+        }
+        return emitter;
+    }
+
+    @GetMapping("/{sessionId}/feedback")
+    public ResponseEntity<ApiResponse<GetFeedbackResponse>> getFeedback(
+            @AuthenticationPrincipal UUID userId,
+            @PathVariable UUID sessionId
+    ) {
+        GetFeedbackResponse response = interviewService.getFeedback(userId, sessionId);
+        if (response.feedbackStatus() == FeedbackStatus.PENDING
+                || response.feedbackStatus() == FeedbackStatus.GENERATING) {
+            return ResponseEntity.status(HttpStatus.ACCEPTED).body(ApiResponse.success(response));
+        }
         return ResponseEntity.ok(ApiResponse.success(response));
     }
 

--- a/src/main/java/app/mockly/domain/interview/controller/InterviewController.java
+++ b/src/main/java/app/mockly/domain/interview/controller/InterviewController.java
@@ -17,14 +17,11 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-import org.springframework.http.codec.ServerSentEvent;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
-import reactor.core.publisher.Flux;
 
 import java.io.IOException;
-import java.time.Duration;
 import java.util.Map;
 import java.util.UUID;
 

--- a/src/main/java/app/mockly/domain/interview/dto/FeedbackContext.java
+++ b/src/main/java/app/mockly/domain/interview/dto/FeedbackContext.java
@@ -1,14 +1,9 @@
 package app.mockly.domain.interview.dto;
 
-import app.mockly.domain.interview.entity.InterviewMessage;
-import app.mockly.domain.interview.entity.InterviewType;
-import app.mockly.domain.product.entity.PlanTier;
-
-import java.util.List;
+import app.mockly.domain.interview.entity.FeedbackStatus;
 
 public record FeedbackContext(
-        List<InterviewMessage> history,
-        InterviewType interviewType,
-        PlanTier planTier
+        FeedbackGenerationContext context,
+        FeedbackStatus feedbackStatus
 ) {
 }

--- a/src/main/java/app/mockly/domain/interview/dto/FeedbackContext.java
+++ b/src/main/java/app/mockly/domain/interview/dto/FeedbackContext.java
@@ -1,0 +1,14 @@
+package app.mockly.domain.interview.dto;
+
+import app.mockly.domain.interview.entity.InterviewMessage;
+import app.mockly.domain.interview.entity.InterviewType;
+import app.mockly.domain.product.entity.PlanTier;
+
+import java.util.List;
+
+public record FeedbackContext(
+        List<InterviewMessage> history,
+        InterviewType interviewType,
+        PlanTier planTier
+) {
+}

--- a/src/main/java/app/mockly/domain/interview/dto/FeedbackGenerationContext.java
+++ b/src/main/java/app/mockly/domain/interview/dto/FeedbackGenerationContext.java
@@ -1,0 +1,14 @@
+package app.mockly.domain.interview.dto;
+
+import app.mockly.domain.interview.entity.InterviewMessage;
+import app.mockly.domain.interview.entity.InterviewType;
+import app.mockly.domain.product.entity.PlanTier;
+
+import java.util.List;
+
+public record FeedbackGenerationContext(
+        List<InterviewMessage> history,
+        InterviewType interviewType,
+        PlanTier planTier
+) {
+}

--- a/src/main/java/app/mockly/domain/interview/dto/InterviewFeedbackResult.java
+++ b/src/main/java/app/mockly/domain/interview/dto/InterviewFeedbackResult.java
@@ -2,6 +2,7 @@ package app.mockly.domain.interview.dto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyDescription;
+import org.springframework.lang.Nullable;
 
 import java.util.List;
 
@@ -18,6 +19,7 @@ public record InterviewFeedbackResult(
         @JsonProperty(required = true, value = "improvements")
         @JsonPropertyDescription("전반적인 개선점 요약")
         String improvements,
+        @Nullable
         @JsonProperty(required = true, value = "detailedAnalysis")
         @JsonPropertyDescription("질문별 상세 분석 (PRO 플랜 전용, 그 외 플랜은 null)")
         String detailedAnalysis

--- a/src/main/java/app/mockly/domain/interview/dto/InterviewFeedbackResult.java
+++ b/src/main/java/app/mockly/domain/interview/dto/InterviewFeedbackResult.java
@@ -1,26 +1,35 @@
 package app.mockly.domain.interview.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyDescription;
 
 import java.util.List;
 
 public record InterviewFeedbackResult(
+        @JsonProperty(required = true, value = "overallScore")
         @JsonPropertyDescription("면접 종합 점수 (1~100)")
         int overallScore,
+        @JsonProperty(required = true, value = "expertFeedbacks")
         @JsonPropertyDescription("전문가별 평가 목록")
         List<ExpertFeedback> expertFeedbacks,
+        @JsonProperty(required = true, value = "strengths")
         @JsonPropertyDescription("전반적인 강점 요약")
         String strengths,
+        @JsonProperty(required = true, value = "improvements")
         @JsonPropertyDescription("전반적인 개선점 요약")
         String improvements,
+        @JsonProperty(required = true, value = "detailedAnalysis")
         @JsonPropertyDescription("질문별 상세 분석 (PRO 플랜 전용, 그 외 플랜은 null)")
         String detailedAnalysis
 ) {
     public record ExpertFeedback(
+            @JsonProperty(required = true, value = "expertRole")
             @JsonPropertyDescription("전문가 역할 (예: 기술 면접관, 커뮤니케이션 전문가, 면접 코치)")
             String expertRole,
+            @JsonProperty(required = true, value = "score")
             @JsonPropertyDescription("해당 전문가 관점의 평가 점수 (1~100)")
             int score,
+            @JsonProperty(required = true, value = "evaluation")
             @JsonPropertyDescription("해당 전문가 관점의 평가 내용")
             String evaluation
     ) {

--- a/src/main/java/app/mockly/domain/interview/dto/QuestionStream.java
+++ b/src/main/java/app/mockly/domain/interview/dto/QuestionStream.java
@@ -1,0 +1,5 @@
+package app.mockly.domain.interview.dto;
+
+import reactor.core.publisher.Flux;
+
+public record QuestionStream(int questionNumber, Flux<String> tokens) {}

--- a/src/main/java/app/mockly/domain/interview/dto/response/FeedbackStatusInfo.java
+++ b/src/main/java/app/mockly/domain/interview/dto/response/FeedbackStatusInfo.java
@@ -1,0 +1,5 @@
+package app.mockly.domain.interview.dto.response;
+
+import app.mockly.domain.interview.entity.FeedbackStatus;
+
+public record FeedbackStatusInfo(FeedbackStatus feedbackStatus, String failReason) {}

--- a/src/main/java/app/mockly/domain/interview/dto/response/GetFeedbackResponse.java
+++ b/src/main/java/app/mockly/domain/interview/dto/response/GetFeedbackResponse.java
@@ -11,6 +11,10 @@ public record GetFeedbackResponse(
         return new GetFeedbackResponse(FeedbackStatus.COMPLETED, feedback, null);
     }
 
+    public static GetFeedbackResponse pending() {
+        return new GetFeedbackResponse(FeedbackStatus.PENDING, null, null);
+    }
+
     public static GetFeedbackResponse generating() {
         return new GetFeedbackResponse(FeedbackStatus.GENERATING, null, null);
     }

--- a/src/main/java/app/mockly/domain/interview/dto/response/GetFeedbackResponse.java
+++ b/src/main/java/app/mockly/domain/interview/dto/response/GetFeedbackResponse.java
@@ -1,0 +1,21 @@
+package app.mockly.domain.interview.dto.response;
+
+import app.mockly.domain.interview.entity.FeedbackStatus;
+
+public record GetFeedbackResponse(
+        FeedbackStatus feedbackStatus,
+        FeedbackDto feedback,
+        String message
+) {
+    public static GetFeedbackResponse completed(FeedbackDto feedback) {
+        return new GetFeedbackResponse(FeedbackStatus.COMPLETED, feedback, null);
+    }
+
+    public static GetFeedbackResponse generating() {
+        return new GetFeedbackResponse(FeedbackStatus.GENERATING, null, null);
+    }
+
+    public static GetFeedbackResponse failed(String message) {
+        return new GetFeedbackResponse(FeedbackStatus.FAILED, null, message);
+    }
+}

--- a/src/main/java/app/mockly/domain/interview/dto/response/GetQuotaResponse.java
+++ b/src/main/java/app/mockly/domain/interview/dto/response/GetQuotaResponse.java
@@ -1,0 +1,13 @@
+package app.mockly.domain.interview.dto.response;
+
+public record GetQuotaResponse(
+        int dailyLimit,
+        int usedToday,
+        int remaining,
+        int maxQuestionsPerSession
+) {
+    public static GetQuotaResponse of(int dailyLimit, long usedToday, int maxQuestionsPerSession) {
+        int used = (int) usedToday; // COUNT 결과, 일일 세션 수는 int 범위 초과 불가
+        return new GetQuotaResponse(dailyLimit, used, Math.max(0, dailyLimit - used), maxQuestionsPerSession);
+    }
+}

--- a/src/main/java/app/mockly/domain/interview/dto/response/SubmitAnswerResponse.java
+++ b/src/main/java/app/mockly/domain/interview/dto/response/SubmitAnswerResponse.java
@@ -1,6 +1,5 @@
 package app.mockly.domain.interview.dto.response;
 
-import app.mockly.domain.interview.dto.InterviewFeedbackResult;
 import app.mockly.domain.interview.entity.InterviewSession;
 
 import java.util.UUID;
@@ -9,26 +8,23 @@ public record SubmitAnswerResponse(
         UUID sessionId,
         int currentQuestionNumber,
         int totalQuestions,
-        boolean isCompleted,
-        InterviewFeedbackResult feedback
+        String sessionStatus
 ) {
     public static SubmitAnswerResponse inProgress(InterviewSession session) {
         return new SubmitAnswerResponse(
                 session.getId(),
                 session.getCurrentQuestionNumber(),
                 session.getTotalQuestions(),
-                false,
-                null
+                session.getStatus().name()
         );
     }
 
-    public static SubmitAnswerResponse completed(InterviewSession session, InterviewFeedbackResult feedback) {
+    public static SubmitAnswerResponse feedbackPending(InterviewSession session) {
         return new SubmitAnswerResponse(
                 session.getId(),
                 session.getCurrentQuestionNumber(),
                 session.getTotalQuestions(),
-                true,
-                feedback
+                session.getStatus().name()
         );
     }
 }

--- a/src/main/java/app/mockly/domain/interview/entity/FeedbackStatus.java
+++ b/src/main/java/app/mockly/domain/interview/entity/FeedbackStatus.java
@@ -1,0 +1,8 @@
+package app.mockly.domain.interview.entity;
+
+public enum FeedbackStatus {
+    PENDING,
+    GENERATING,
+    COMPLETED,
+    FAILED
+}

--- a/src/main/java/app/mockly/domain/interview/entity/InterviewSession.java
+++ b/src/main/java/app/mockly/domain/interview/entity/InterviewSession.java
@@ -95,6 +95,7 @@ public class InterviewSession extends BaseEntity {
     }
 
     public void markFeedbackFailed(String reason) {
+        if (this.feedbackStatus == FeedbackStatus.COMPLETED) return;
         this.feedbackStatus = FeedbackStatus.FAILED;
         this.failReason = reason != null && reason.length() > 500 ? reason.substring(0, 500) : reason;
     }

--- a/src/main/java/app/mockly/domain/interview/entity/InterviewSession.java
+++ b/src/main/java/app/mockly/domain/interview/entity/InterviewSession.java
@@ -51,6 +51,9 @@ public class InterviewSession extends BaseEntity {
 
     private Instant completedAt;
 
+    @Column(length = 100)
+    private String firstQuestionKeyword;
+
     public static InterviewSession create(User user, String position, ExperienceLevel experienceLevel,
                                           InterviewType interviewType, int totalQuestions, String selfIntroduction) {
         return InterviewSession.builder()
@@ -76,6 +79,10 @@ public class InterviewSession extends BaseEntity {
 
     public void abandon() {
         this.status = InterviewSessionStatus.ABANDONED;
+    }
+
+    public void setFirstQuestionKeyword(String keyword) {
+        this.firstQuestionKeyword = keyword;
     }
 
     public boolean isAllQuestionsAnswered() {

--- a/src/main/java/app/mockly/domain/interview/entity/InterviewSession.java
+++ b/src/main/java/app/mockly/domain/interview/entity/InterviewSession.java
@@ -54,6 +54,13 @@ public class InterviewSession extends BaseEntity {
     @Column(length = 100)
     private String firstQuestionKeyword;
 
+    @Enumerated(EnumType.STRING)
+    @Column(length = 20)
+    private FeedbackStatus feedbackStatus;
+
+    @Column(length = 500)
+    private String failReason;
+
     public static InterviewSession create(User user, String position, ExperienceLevel experienceLevel,
                                           InterviewType interviewType, int totalQuestions, String selfIntroduction) {
         return InterviewSession.builder()
@@ -72,9 +79,29 @@ public class InterviewSession extends BaseEntity {
         this.currentQuestionNumber++;
     }
 
+    public void startFeedbackGeneration() {
+        this.status = InterviewSessionStatus.FEEDBACK_PENDING;
+        this.feedbackStatus = FeedbackStatus.PENDING;
+    }
+
+    public void markFeedbackGenerating() {
+        this.feedbackStatus = FeedbackStatus.GENERATING;
+    }
+
     public void complete() {
         this.status = InterviewSessionStatus.COMPLETED;
+        this.feedbackStatus = FeedbackStatus.COMPLETED;
         this.completedAt = Instant.now();
+    }
+
+    public void markFeedbackFailed(String reason) {
+        this.feedbackStatus = FeedbackStatus.FAILED;
+        this.failReason = reason != null && reason.length() > 500 ? reason.substring(0, 500) : reason;
+    }
+
+    public void resetFeedbackStatus() {
+        this.feedbackStatus = FeedbackStatus.PENDING;
+        this.failReason = null;
     }
 
     public void abandon() {

--- a/src/main/java/app/mockly/domain/interview/entity/InterviewSessionStatus.java
+++ b/src/main/java/app/mockly/domain/interview/entity/InterviewSessionStatus.java
@@ -2,6 +2,7 @@ package app.mockly.domain.interview.entity;
 
 public enum InterviewSessionStatus {
     IN_PROGRESS,
+    FEEDBACK_PENDING,
     COMPLETED,
     ABANDONED
 }

--- a/src/main/java/app/mockly/domain/interview/event/FeedbackRequestedEvent.java
+++ b/src/main/java/app/mockly/domain/interview/event/FeedbackRequestedEvent.java
@@ -1,0 +1,6 @@
+package app.mockly.domain.interview.event;
+
+import java.util.UUID;
+
+public record FeedbackRequestedEvent(UUID sessionId, UUID userId) {
+}

--- a/src/main/java/app/mockly/domain/interview/repository/InterviewSessionRepository.java
+++ b/src/main/java/app/mockly/domain/interview/repository/InterviewSessionRepository.java
@@ -24,4 +24,5 @@ public interface InterviewSessionRepository extends JpaRepository<InterviewSessi
     Page<InterviewSession> findByUserIdAndStatus(UUID userId, InterviewSessionStatus status, Pageable pageable);
 
     Page<InterviewSession> findByUserId(UUID userId, Pageable pageable);
+
 }

--- a/src/main/java/app/mockly/domain/interview/repository/InterviewSessionRepository.java
+++ b/src/main/java/app/mockly/domain/interview/repository/InterviewSessionRepository.java
@@ -6,6 +6,7 @@ import app.mockly.domain.interview.entity.InterviewSessionStatus;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -28,5 +29,35 @@ public interface InterviewSessionRepository extends JpaRepository<InterviewSessi
     Page<InterviewSession> findByUserId(UUID userId, Pageable pageable);
 
     List<InterviewSession> findByFeedbackStatusInAndUpdatedAtBefore(List<FeedbackStatus> statuses, Instant threshold);
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("""
+            UPDATE InterviewSession s
+            SET s.feedbackStatus = :generatingStatus,
+                s.updatedAt = :updatedAt
+            WHERE s.id = :sessionId
+              AND s.feedbackStatus = :pendingStatus
+            """)
+    int markFeedbackGeneratingIfPending(@Param("sessionId") UUID sessionId,
+                                        @Param("pendingStatus") FeedbackStatus pendingStatus,
+                                        @Param("generatingStatus") FeedbackStatus generatingStatus,
+                                        @Param("updatedAt") Instant updatedAt);
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("""
+            UPDATE InterviewSession s
+            SET s.status = :completedSessionStatus,
+                s.feedbackStatus = :completedFeedbackStatus,
+                s.completedAt = :completedAt,
+                s.updatedAt = :updatedAt
+            WHERE s.id = :sessionId
+              AND s.feedbackStatus = :generatingStatus
+            """)
+    int completeFeedbackIfGenerating(@Param("sessionId") UUID sessionId,
+                                     @Param("generatingStatus") FeedbackStatus generatingStatus,
+                                     @Param("completedFeedbackStatus") FeedbackStatus completedFeedbackStatus,
+                                     @Param("completedSessionStatus") InterviewSessionStatus completedSessionStatus,
+                                     @Param("completedAt") Instant completedAt,
+                                     @Param("updatedAt") Instant updatedAt);
 
 }

--- a/src/main/java/app/mockly/domain/interview/repository/InterviewSessionRepository.java
+++ b/src/main/java/app/mockly/domain/interview/repository/InterviewSessionRepository.java
@@ -1,5 +1,6 @@
 package app.mockly.domain.interview.repository;
 
+import app.mockly.domain.interview.entity.FeedbackStatus;
 import app.mockly.domain.interview.entity.InterviewSession;
 import app.mockly.domain.interview.entity.InterviewSessionStatus;
 import org.springframework.data.domain.Page;
@@ -9,6 +10,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.time.Instant;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -24,5 +26,7 @@ public interface InterviewSessionRepository extends JpaRepository<InterviewSessi
     Page<InterviewSession> findByUserIdAndStatus(UUID userId, InterviewSessionStatus status, Pageable pageable);
 
     Page<InterviewSession> findByUserId(UUID userId, Pageable pageable);
+
+    List<InterviewSession> findByFeedbackStatusInAndUpdatedAtBefore(List<FeedbackStatus> statuses, Instant threshold);
 
 }

--- a/src/main/java/app/mockly/domain/interview/service/FeedbackGenerationHandler.java
+++ b/src/main/java/app/mockly/domain/interview/service/FeedbackGenerationHandler.java
@@ -67,6 +67,12 @@ public class FeedbackGenerationHandler {
             } catch (Exception inner) {
                 log.error("피드백 실패 마킹 중 오류 sessionId={}", sessionId, inner);
             }
+            if (failedStatus == FeedbackStatus.COMPLETED) {
+                log.info("피드백 생성 실패 처리 스킵: 이미 완료된 세션 sessionId={}", sessionId);
+                feedbackSseManager.send(sessionId, failedStatus);
+                feedbackSseManager.complete(sessionId);
+                return;
+            }
             feedbackSseManager.send(sessionId, failedStatus, "피드백 생성에 실패했습니다.");
             feedbackSseManager.complete(sessionId);
 

--- a/src/main/java/app/mockly/domain/interview/service/FeedbackGenerationHandler.java
+++ b/src/main/java/app/mockly/domain/interview/service/FeedbackGenerationHandler.java
@@ -1,0 +1,96 @@
+package app.mockly.domain.interview.service;
+
+import app.mockly.domain.interview.dto.FeedbackContext;
+import app.mockly.domain.interview.dto.InterviewFeedbackResult;
+import app.mockly.domain.interview.entity.FeedbackStatus;
+import app.mockly.domain.interview.event.FeedbackRequestedEvent;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+import java.util.UUID;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class FeedbackGenerationHandler {
+
+    private static final int MAX_RETRY = 3;
+
+    private final FeedbackTransactionHelper txHelper;
+    private final InterviewAiService interviewAiService;
+    private final FeedbackSseManager feedbackSseManager;
+    private final ObjectMapper objectMapper;
+
+    @Async("feedbackExecutor")
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handle(FeedbackRequestedEvent event) {
+        UUID sessionId = event.sessionId();
+        UUID userId = event.userId();
+
+        try {
+            // TX2: GENERATING 설정 + AI 호출에 필요한 데이터 로딩
+            FeedbackContext ctx = txHelper.markGeneratingAndLoadContext(sessionId, userId);
+            feedbackSseManager.send(sessionId, FeedbackStatus.GENERATING);
+
+            // NO TX: AI 호출 (재시도 포함)
+            InterviewFeedbackResult result = callAiWithRetry(sessionId, ctx);
+            String serializedExperts = serializeExperts(result);
+
+            // TX3-success: 피드백 저장 + 세션 완료
+            txHelper.saveFeedbackAndComplete(sessionId, result, serializedExperts);
+            feedbackSseManager.send(sessionId, FeedbackStatus.COMPLETED);
+            feedbackSseManager.complete(sessionId);
+
+        } catch (Exception e) {
+            log.error("피드백 생성 실패 sessionId={}", sessionId, e);
+            try {
+                // TX3-fail: 실패 마킹
+                txHelper.markFailed(sessionId, e.getMessage());
+            } catch (Exception inner) {
+                log.error("피드백 실패 마킹 중 오류 sessionId={}", sessionId, inner);
+            }
+            feedbackSseManager.send(sessionId, FeedbackStatus.FAILED, "피드백 생성에 실패했습니다.");
+            feedbackSseManager.complete(sessionId);
+
+            if (e.getCause() instanceof InterruptedException) {
+                Thread.currentThread().interrupt();
+            }
+        }
+    }
+
+    private InterviewFeedbackResult callAiWithRetry(UUID sessionId, FeedbackContext ctx) {
+        Exception lastException = null;
+        for (int attempt = 0; attempt < MAX_RETRY; attempt++) {
+            try {
+                return interviewAiService.generateFeedback(
+                        ctx.history(), ctx.interviewType(), ctx.planTier());
+            } catch (Exception e) {
+                lastException = e;
+                log.warn("AI 피드백 생성 실패 sessionId={} (attempt={}/{}): {}",
+                        sessionId, attempt + 1, MAX_RETRY, e.getMessage());
+                if (attempt < MAX_RETRY - 1) {
+                    try {
+                        Thread.sleep(1000L * (1L << attempt)); // 1s → 2s
+                    } catch (InterruptedException ie) {
+                        Thread.currentThread().interrupt();
+                        throw new RuntimeException("피드백 생성 중 인터럽트 발생", ie);
+                    }
+                }
+            }
+        }
+        throw new RuntimeException("AI 피드백 생성 " + MAX_RETRY + "회 모두 실패", lastException);
+    }
+
+    private String serializeExperts(InterviewFeedbackResult result) {
+        try {
+            return objectMapper.writeValueAsString(result.expertFeedbacks());
+        } catch (Exception e) {
+            throw new RuntimeException("전문가 피드백 직렬화 실패", e);
+        }
+    }
+}

--- a/src/main/java/app/mockly/domain/interview/service/FeedbackGenerationHandler.java
+++ b/src/main/java/app/mockly/domain/interview/service/FeedbackGenerationHandler.java
@@ -58,6 +58,9 @@ public class FeedbackGenerationHandler {
             feedbackSseManager.complete(sessionId);
         } catch (FeedbackTransactionHelper.FeedbackCompletionException e) {
             log.error("피드백 완료 저장 실패 sessionId={}", sessionId, e);
+        } catch (FeedbackInterruptedException e) {
+            log.warn("피드백 생성 작업 인터럽트 sessionId={}", sessionId, e);
+            Thread.currentThread().interrupt();
         } catch (Exception e) {
             log.error("피드백 생성 실패 sessionId={}", sessionId, e);
             FeedbackStatus failedStatus = FeedbackStatus.FAILED;
@@ -89,6 +92,10 @@ public class FeedbackGenerationHandler {
                 return interviewAiService.generateFeedback(
                         ctx.history(), ctx.interviewType(), ctx.planTier());
             } catch (Exception e) {
+                if (hasInterruptedCause(e)) {
+                    Thread.currentThread().interrupt();
+                    throw new FeedbackInterruptedException("피드백 생성 중 인터럽트 발생", e);
+                }
                 lastException = e;
                 log.warn("AI 피드백 생성 실패 sessionId={} (attempt={}/{}): {}",
                         sessionId, attempt + 1, MAX_RETRY, e.getMessage());
@@ -97,7 +104,7 @@ public class FeedbackGenerationHandler {
                         Thread.sleep(1000L * (1L << attempt)); // 1s → 2s
                     } catch (InterruptedException ie) {
                         Thread.currentThread().interrupt();
-                        throw new RuntimeException("피드백 생성 중 인터럽트 발생", ie);
+                        throw new FeedbackInterruptedException("피드백 생성 중 인터럽트 발생", ie);
                     }
                 }
             }
@@ -110,6 +117,23 @@ public class FeedbackGenerationHandler {
             return objectMapper.writeValueAsString(result.expertFeedbacks());
         } catch (Exception e) {
             throw new FeedbackTransactionHelper.FeedbackCompletionException("전문가 피드백 직렬화 실패", e);
+        }
+    }
+
+    private boolean hasInterruptedCause(Throwable throwable) {
+        Throwable current = throwable;
+        while (current != null) {
+            if (current instanceof InterruptedException) {
+                return true;
+            }
+            current = current.getCause();
+        }
+        return false;
+    }
+
+    private static class FeedbackInterruptedException extends RuntimeException {
+        private FeedbackInterruptedException(String message, Throwable cause) {
+            super(message, cause);
         }
     }
 }

--- a/src/main/java/app/mockly/domain/interview/service/FeedbackGenerationHandler.java
+++ b/src/main/java/app/mockly/domain/interview/service/FeedbackGenerationHandler.java
@@ -13,6 +13,7 @@ import org.springframework.stereotype.Component;
 import org.springframework.transaction.event.TransactionPhase;
 import org.springframework.transaction.event.TransactionalEventListener;
 
+import java.util.Optional;
 import java.util.UUID;
 
 @Slf4j
@@ -35,17 +36,28 @@ public class FeedbackGenerationHandler {
 
         try {
             // TX2: GENERATING 설정 + AI 호출에 필요한 데이터 로딩
-            FeedbackContext ctx = txHelper.markGeneratingAndLoadContext(sessionId, userId);
+            Optional<FeedbackContext> feedbackContext = txHelper.markGeneratingAndLoadContext(sessionId, userId);
+            if (feedbackContext.isEmpty()) {
+                log.info("피드백 생성 작업 스킵: 이미 처리 중이거나 완료된 세션 sessionId={}", sessionId);
+                return;
+            }
+            FeedbackContext ctx = feedbackContext.get();
             feedbackSseManager.send(sessionId, ctx.feedbackStatus());
 
             // NO TX: AI 호출 (재시도 포함)
             InterviewFeedbackResult result = callAiWithRetry(sessionId, ctx.context());
-            String serializedExperts = serializeExperts(result);
 
             // TX3-success: 피드백 저장 + 세션 완료
-            FeedbackStatus completedStatus = txHelper.saveFeedbackAndComplete(sessionId, result, serializedExperts);
-            feedbackSseManager.send(sessionId, completedStatus);
+            String serializedExperts = serializeExperts(result);
+            Optional<FeedbackStatus> completedStatus = txHelper.saveFeedbackAndComplete(sessionId, result, serializedExperts);
+            if (completedStatus.isEmpty()) {
+                log.info("피드백 완료 저장 스킵: 이미 완료 처리 중이거나 완료된 세션 sessionId={}", sessionId);
+                return;
+            }
+            feedbackSseManager.send(sessionId, completedStatus.get());
             feedbackSseManager.complete(sessionId);
+        } catch (FeedbackTransactionHelper.FeedbackCompletionException e) {
+            log.error("피드백 완료 저장 실패 sessionId={}", sessionId, e);
         } catch (Exception e) {
             log.error("피드백 생성 실패 sessionId={}", sessionId, e);
             FeedbackStatus failedStatus = FeedbackStatus.FAILED;
@@ -91,7 +103,7 @@ public class FeedbackGenerationHandler {
         try {
             return objectMapper.writeValueAsString(result.expertFeedbacks());
         } catch (Exception e) {
-            throw new RuntimeException("전문가 피드백 직렬화 실패", e);
+            throw new FeedbackTransactionHelper.FeedbackCompletionException("전문가 피드백 직렬화 실패", e);
         }
     }
 }

--- a/src/main/java/app/mockly/domain/interview/service/FeedbackGenerationHandler.java
+++ b/src/main/java/app/mockly/domain/interview/service/FeedbackGenerationHandler.java
@@ -1,6 +1,7 @@
 package app.mockly.domain.interview.service;
 
 import app.mockly.domain.interview.dto.FeedbackContext;
+import app.mockly.domain.interview.dto.FeedbackGenerationContext;
 import app.mockly.domain.interview.dto.InterviewFeedbackResult;
 import app.mockly.domain.interview.entity.FeedbackStatus;
 import app.mockly.domain.interview.event.FeedbackRequestedEvent;
@@ -35,26 +36,26 @@ public class FeedbackGenerationHandler {
         try {
             // TX2: GENERATING 설정 + AI 호출에 필요한 데이터 로딩
             FeedbackContext ctx = txHelper.markGeneratingAndLoadContext(sessionId, userId);
-            feedbackSseManager.send(sessionId, FeedbackStatus.GENERATING);
+            feedbackSseManager.send(sessionId, ctx.feedbackStatus());
 
             // NO TX: AI 호출 (재시도 포함)
-            InterviewFeedbackResult result = callAiWithRetry(sessionId, ctx);
+            InterviewFeedbackResult result = callAiWithRetry(sessionId, ctx.context());
             String serializedExperts = serializeExperts(result);
 
             // TX3-success: 피드백 저장 + 세션 완료
-            txHelper.saveFeedbackAndComplete(sessionId, result, serializedExperts);
-            feedbackSseManager.send(sessionId, FeedbackStatus.COMPLETED);
+            FeedbackStatus completedStatus = txHelper.saveFeedbackAndComplete(sessionId, result, serializedExperts);
+            feedbackSseManager.send(sessionId, completedStatus);
             feedbackSseManager.complete(sessionId);
-
         } catch (Exception e) {
             log.error("피드백 생성 실패 sessionId={}", sessionId, e);
+            FeedbackStatus failedStatus = FeedbackStatus.FAILED;
             try {
                 // TX3-fail: 실패 마킹
-                txHelper.markFailed(sessionId, e.getMessage());
+                failedStatus = txHelper.markFailed(sessionId, e.getMessage());
             } catch (Exception inner) {
                 log.error("피드백 실패 마킹 중 오류 sessionId={}", sessionId, inner);
             }
-            feedbackSseManager.send(sessionId, FeedbackStatus.FAILED, "피드백 생성에 실패했습니다.");
+            feedbackSseManager.send(sessionId, failedStatus, "피드백 생성에 실패했습니다.");
             feedbackSseManager.complete(sessionId);
 
             if (e.getCause() instanceof InterruptedException) {
@@ -63,7 +64,7 @@ public class FeedbackGenerationHandler {
         }
     }
 
-    private InterviewFeedbackResult callAiWithRetry(UUID sessionId, FeedbackContext ctx) {
+    private InterviewFeedbackResult callAiWithRetry(UUID sessionId, FeedbackGenerationContext ctx) {
         Exception lastException = null;
         for (int attempt = 0; attempt < MAX_RETRY; attempt++) {
             try {

--- a/src/main/java/app/mockly/domain/interview/service/FeedbackSseManager.java
+++ b/src/main/java/app/mockly/domain/interview/service/FeedbackSseManager.java
@@ -1,0 +1,67 @@
+package app.mockly.domain.interview.service;
+
+import app.mockly.domain.interview.entity.FeedbackStatus;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class FeedbackSseManager {
+
+    private final ConcurrentHashMap<UUID, SseEmitter> emitters = new ConcurrentHashMap<>();
+    private final ObjectMapper objectMapper;
+
+    public SseEmitter connect(UUID sessionId, long timeout) {
+        SseEmitter emitter = new SseEmitter(timeout);
+        SseEmitter previous = emitters.put(sessionId, emitter);
+        if (previous != null) {
+            try { previous.complete(); } catch (Exception ignored) {}
+        }
+        // remove(key, value): 재연결 시 새 emitter를 삭제하는 버그 방지
+        emitter.onCompletion(() -> emitters.remove(sessionId, emitter));
+        emitter.onTimeout(() -> emitters.remove(sessionId, emitter));
+        emitter.onError(e -> emitters.remove(sessionId, emitter));
+        return emitter;
+    }
+
+    public void send(UUID sessionId, FeedbackStatus status) {
+        send(sessionId, status, null);
+    }
+
+    public void send(UUID sessionId, FeedbackStatus status, String message) {
+        SseEmitter emitter = emitters.get(sessionId);
+        if (emitter == null) return;
+
+        try {
+            Map<String, Object> payload = message != null
+                    ? Map.of("feedbackStatus", status.name(), "message", message)
+                    : Map.of("feedbackStatus", status.name());
+            emitter.send(SseEmitter.event()
+                    .name("status")
+                    .data(objectMapper.writeValueAsString(payload)));
+        } catch (IOException e) {
+            log.warn("SSE 전송 실패 sessionId={}", sessionId, e);
+            emitters.remove(sessionId, emitter);
+        }
+    }
+
+    public void complete(UUID sessionId) {
+        SseEmitter emitter = emitters.get(sessionId);
+        if (emitter == null) return;
+        try {
+            emitter.complete();
+        } catch (Exception e) {
+            log.warn("SSE complete 실패 sessionId={}", sessionId, e);
+        }
+        emitters.remove(sessionId, emitter);
+    }
+}

--- a/src/main/java/app/mockly/domain/interview/service/FeedbackTransactionHelper.java
+++ b/src/main/java/app/mockly/domain/interview/service/FeedbackTransactionHelper.java
@@ -6,6 +6,7 @@ import app.mockly.domain.interview.dto.InterviewFeedbackResult;
 import app.mockly.domain.interview.entity.FeedbackStatus;
 import app.mockly.domain.interview.entity.InterviewFeedback;
 import app.mockly.domain.interview.entity.InterviewSession;
+import app.mockly.domain.interview.entity.InterviewSessionStatus;
 import app.mockly.domain.interview.repository.InterviewFeedbackRepository;
 import app.mockly.domain.interview.repository.InterviewMessageRepository;
 import app.mockly.domain.interview.repository.InterviewSessionRepository;
@@ -20,6 +21,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.Instant;
+import java.util.Optional;
 import java.util.UUID;
 
 @Slf4j
@@ -33,10 +36,18 @@ public class FeedbackTransactionHelper {
     private final SubscriptionRepository subscriptionRepository;
 
     @Transactional(propagation = Propagation.REQUIRES_NEW)
-    public FeedbackContext markGeneratingAndLoadContext(UUID sessionId, UUID userId) {
+    public Optional<FeedbackContext> markGeneratingAndLoadContext(UUID sessionId, UUID userId) {
+        int updatedRows = interviewSessionRepository.markFeedbackGeneratingIfPending(
+                sessionId, FeedbackStatus.PENDING, FeedbackStatus.GENERATING, Instant.now());
+        if (updatedRows == 0) {
+            if (!interviewSessionRepository.existsById(sessionId)) {
+                throw new BusinessException(ApiStatusCode.RESOURCE_NOT_FOUND);
+            }
+            return Optional.empty();
+        }
+
         InterviewSession session = interviewSessionRepository.findById(sessionId)
                 .orElseThrow(() -> new BusinessException(ApiStatusCode.RESOURCE_NOT_FOUND));
-        session.markFeedbackGenerating();
 
         PlanTier planTier = subscriptionRepository.findByUserIdAndStatus(userId, SubscriptionStatus.ACTIVE)
                 .map(sub -> sub.getSubscriptionPlan().getProduct().getPlanTier())
@@ -46,25 +57,37 @@ public class FeedbackTransactionHelper {
                 session.getInterviewType(),
                 planTier
         );
-        return new FeedbackContext(genCtx, session.getFeedbackStatus());
+        return Optional.of(new FeedbackContext(genCtx, session.getFeedbackStatus()));
     }
 
     @Transactional(propagation = Propagation.REQUIRES_NEW)
-    public FeedbackStatus saveFeedbackAndComplete(UUID sessionId, InterviewFeedbackResult result, String serializedExperts) {
-        InterviewSession session = interviewSessionRepository.findById(sessionId)
-                .orElseThrow(() -> new BusinessException(ApiStatusCode.RESOURCE_NOT_FOUND));
+    public Optional<FeedbackStatus> saveFeedbackAndComplete(UUID sessionId, InterviewFeedbackResult result, String serializedExperts) {
+        Instant now = Instant.now();
+        int updatedRows = interviewSessionRepository.completeFeedbackIfGenerating(
+                sessionId,
+                FeedbackStatus.GENERATING,
+                FeedbackStatus.COMPLETED,
+                InterviewSessionStatus.COMPLETED,
+                now,
+                now);
+        if (updatedRows == 0) {
+            return Optional.empty();
+        }
 
-        interviewFeedbackRepository.save(InterviewFeedback.create(
-                session,
-                result.overallScore(),
-                serializedExperts,
-                result.strengths(),
-                result.improvements(),
-                result.detailedAnalysis()
-        ));
-
-        session.complete();
-        return session.getFeedbackStatus();
+        try {
+            InterviewSession session = interviewSessionRepository.getReferenceById(sessionId);
+            interviewFeedbackRepository.saveAndFlush(InterviewFeedback.create(
+                    session,
+                    result.overallScore(),
+                    serializedExperts,
+                    result.strengths(),
+                    result.improvements(),
+                    result.detailedAnalysis()
+            ));
+            return Optional.of(FeedbackStatus.COMPLETED);
+        } catch (Exception e) {
+            throw new FeedbackCompletionException("피드백 완료 저장 실패", e);
+        }
     }
 
     @Transactional(propagation = Propagation.REQUIRES_NEW)
@@ -75,5 +98,11 @@ public class FeedbackTransactionHelper {
                     return session.getFeedbackStatus();
                 })
                 .orElse(FeedbackStatus.FAILED);
+    }
+
+    public static class FeedbackCompletionException extends RuntimeException {
+        public FeedbackCompletionException(String message, Throwable cause) {
+            super(message, cause);
+        }
     }
 }

--- a/src/main/java/app/mockly/domain/interview/service/FeedbackTransactionHelper.java
+++ b/src/main/java/app/mockly/domain/interview/service/FeedbackTransactionHelper.java
@@ -1,7 +1,9 @@
 package app.mockly.domain.interview.service;
 
 import app.mockly.domain.interview.dto.FeedbackContext;
+import app.mockly.domain.interview.dto.FeedbackGenerationContext;
 import app.mockly.domain.interview.dto.InterviewFeedbackResult;
+import app.mockly.domain.interview.entity.FeedbackStatus;
 import app.mockly.domain.interview.entity.InterviewFeedback;
 import app.mockly.domain.interview.entity.InterviewSession;
 import app.mockly.domain.interview.repository.InterviewFeedbackRepository;
@@ -39,15 +41,16 @@ public class FeedbackTransactionHelper {
         PlanTier planTier = subscriptionRepository.findByUserIdAndStatus(userId, SubscriptionStatus.ACTIVE)
                 .map(sub -> sub.getSubscriptionPlan().getProduct().getPlanTier())
                 .orElse(PlanTier.FREE);
-        return new FeedbackContext(
+        FeedbackGenerationContext genCtx = new FeedbackGenerationContext(
                 interviewMessageRepository.findBySessionIdOrderByIdAsc(sessionId),
                 session.getInterviewType(),
                 planTier
         );
+        return new FeedbackContext(genCtx, session.getFeedbackStatus());
     }
 
     @Transactional(propagation = Propagation.REQUIRES_NEW)
-    public void saveFeedbackAndComplete(UUID sessionId, InterviewFeedbackResult result, String serializedExperts) {
+    public FeedbackStatus saveFeedbackAndComplete(UUID sessionId, InterviewFeedbackResult result, String serializedExperts) {
         InterviewSession session = interviewSessionRepository.findById(sessionId)
                 .orElseThrow(() -> new BusinessException(ApiStatusCode.RESOURCE_NOT_FOUND));
 
@@ -61,11 +64,16 @@ public class FeedbackTransactionHelper {
         ));
 
         session.complete();
+        return session.getFeedbackStatus();
     }
 
     @Transactional(propagation = Propagation.REQUIRES_NEW)
-    public void markFailed(UUID sessionId, String reason) {
-        interviewSessionRepository.findById(sessionId)
-                .ifPresent(session -> session.markFeedbackFailed(reason));
+    public FeedbackStatus markFailed(UUID sessionId, String reason) {
+        return interviewSessionRepository.findById(sessionId)
+                .map(session -> {
+                    session.markFeedbackFailed(reason);
+                    return session.getFeedbackStatus();
+                })
+                .orElse(FeedbackStatus.FAILED);
     }
 }

--- a/src/main/java/app/mockly/domain/interview/service/FeedbackTransactionHelper.java
+++ b/src/main/java/app/mockly/domain/interview/service/FeedbackTransactionHelper.java
@@ -1,0 +1,71 @@
+package app.mockly.domain.interview.service;
+
+import app.mockly.domain.interview.dto.FeedbackContext;
+import app.mockly.domain.interview.dto.InterviewFeedbackResult;
+import app.mockly.domain.interview.entity.InterviewFeedback;
+import app.mockly.domain.interview.entity.InterviewSession;
+import app.mockly.domain.interview.repository.InterviewFeedbackRepository;
+import app.mockly.domain.interview.repository.InterviewMessageRepository;
+import app.mockly.domain.interview.repository.InterviewSessionRepository;
+import app.mockly.domain.product.entity.PlanTier;
+import app.mockly.domain.product.entity.SubscriptionStatus;
+import app.mockly.domain.product.repository.SubscriptionRepository;
+import app.mockly.global.common.ApiStatusCode;
+import app.mockly.global.exception.BusinessException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.UUID;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class FeedbackTransactionHelper {
+
+    private final InterviewSessionRepository interviewSessionRepository;
+    private final InterviewMessageRepository interviewMessageRepository;
+    private final InterviewFeedbackRepository interviewFeedbackRepository;
+    private final SubscriptionRepository subscriptionRepository;
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public FeedbackContext markGeneratingAndLoadContext(UUID sessionId, UUID userId) {
+        InterviewSession session = interviewSessionRepository.findById(sessionId)
+                .orElseThrow(() -> new BusinessException(ApiStatusCode.RESOURCE_NOT_FOUND));
+        session.markFeedbackGenerating();
+
+        PlanTier planTier = subscriptionRepository.findByUserIdAndStatus(userId, SubscriptionStatus.ACTIVE)
+                .map(sub -> sub.getSubscriptionPlan().getProduct().getPlanTier())
+                .orElse(PlanTier.FREE);
+        return new FeedbackContext(
+                interviewMessageRepository.findBySessionIdOrderByIdAsc(sessionId),
+                session.getInterviewType(),
+                planTier
+        );
+    }
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void saveFeedbackAndComplete(UUID sessionId, InterviewFeedbackResult result, String serializedExperts) {
+        InterviewSession session = interviewSessionRepository.findById(sessionId)
+                .orElseThrow(() -> new BusinessException(ApiStatusCode.RESOURCE_NOT_FOUND));
+
+        interviewFeedbackRepository.save(InterviewFeedback.create(
+                session,
+                result.overallScore(),
+                serializedExperts,
+                result.strengths(),
+                result.improvements(),
+                result.detailedAnalysis()
+        ));
+
+        session.complete();
+    }
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void markFailed(UUID sessionId, String reason) {
+        interviewSessionRepository.findById(sessionId)
+                .ifPresent(session -> session.markFeedbackFailed(reason));
+    }
+}

--- a/src/main/java/app/mockly/domain/interview/service/InterviewAiService.java
+++ b/src/main/java/app/mockly/domain/interview/service/InterviewAiService.java
@@ -12,6 +12,8 @@ import app.mockly.global.config.InterviewAiProperties;
 import app.mockly.global.exception.BusinessException;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.ai.chat.client.AdvisorParams;
 import org.springframework.ai.chat.client.ChatClient;
@@ -28,12 +30,14 @@ public class InterviewAiService {
     private final ChatClient chatClient;
     private final ObjectMapper objectMapper;
     private final InterviewAiProperties interviewAiProperties;
+    private final MeterRegistry meterRegistry;
 
     public InterviewAiService(ChatClient.Builder chatClientBuilder, ObjectMapper objectMapper,
-                              InterviewAiProperties interviewAiProperties) {
+                              InterviewAiProperties interviewAiProperties, MeterRegistry meterRegistry) {
         this.chatClient = chatClientBuilder.build();
         this.objectMapper = objectMapper;
         this.interviewAiProperties = interviewAiProperties;
+        this.meterRegistry = meterRegistry;
     }
 
     public Flux<String> generateFirstQuestion(InterviewSession session) {
@@ -221,14 +225,22 @@ public class InterviewAiService {
                 위 면접 내용을 평가하여 피드백을 제공하세요.
                 """.formatted(interviewType.getDescription(), formatHistory(history));
 
+        Timer.Sample sample = Timer.start(meterRegistry);
         try {
-            return chatClient.prompt()
+            InterviewFeedbackResult result = chatClient.prompt()
                     .advisors(AdvisorParams.ENABLE_NATIVE_STRUCTURED_OUTPUT)
                     .system(systemPrompt)
                     .user(userPrompt)
                     .call()
                     .entity(InterviewFeedbackResult.class);
+            sample.stop(Timer.builder("ai.feedback.duration")
+                    .tag("status", "success")
+                    .register(meterRegistry));
+            return result;
         } catch (Exception e) {
+            sample.stop(Timer.builder("ai.feedback.duration")
+                    .tag("status", "error")
+                    .register(meterRegistry));
             log.error("AI 피드백 생성 실패", e);
             throw new BusinessException(ApiStatusCode.AI_SERVICE_ERROR);
         }

--- a/src/main/java/app/mockly/domain/interview/service/InterviewAiService.java
+++ b/src/main/java/app/mockly/domain/interview/service/InterviewAiService.java
@@ -8,6 +8,7 @@ import app.mockly.domain.interview.entity.InterviewSession;
 import app.mockly.domain.interview.entity.InterviewType;
 import app.mockly.domain.product.entity.PlanTier;
 import app.mockly.global.common.ApiStatusCode;
+import app.mockly.global.config.InterviewAiProperties;
 import app.mockly.global.exception.BusinessException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.extern.slf4j.Slf4j;
@@ -24,10 +25,13 @@ public class InterviewAiService {
 
     private final ChatClient chatClient;
     private final ObjectMapper objectMapper;
+    private final InterviewAiProperties interviewAiProperties;
 
-    public InterviewAiService(ChatClient.Builder chatClientBuilder, ObjectMapper objectMapper) {
+    public InterviewAiService(ChatClient.Builder chatClientBuilder, ObjectMapper objectMapper,
+                              InterviewAiProperties interviewAiProperties) {
         this.chatClient = chatClientBuilder.build();
         this.objectMapper = objectMapper;
+        this.interviewAiProperties = interviewAiProperties;
     }
 
     public Flux<String> generateFirstQuestion(InterviewSession session) {
@@ -320,8 +324,8 @@ public class InterviewAiService {
         try {
             String raw = chatClient.prompt()
                     .options(OpenAiChatOptions.builder()
-                            .model("gpt-4o-mini")
-                            .temperature(0.7)
+                            .model(interviewAiProperties.getKeywordExtractionModel())
+                            .temperature(interviewAiProperties.getKeywordExtractionTemperature())
                             .build())
                     .user(prompt)
                     .call()

--- a/src/main/java/app/mockly/domain/interview/service/InterviewAiService.java
+++ b/src/main/java/app/mockly/domain/interview/service/InterviewAiService.java
@@ -10,8 +10,10 @@ import app.mockly.domain.product.entity.PlanTier;
 import app.mockly.global.common.ApiStatusCode;
 import app.mockly.global.config.InterviewAiProperties;
 import app.mockly.global.exception.BusinessException;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.ai.chat.client.AdvisorParams;
 import org.springframework.ai.chat.client.ChatClient;
 import org.springframework.ai.openai.OpenAiChatOptions;
 import org.springframework.stereotype.Service;
@@ -197,8 +199,6 @@ public class InterviewAiService {
     public InterviewFeedbackResult generateFeedback(List<InterviewMessage> history, InterviewType interviewType, PlanTier plan) {
         String systemPrompt = """
                 당신은 면접 평가 시스템입니다. 면접이 끝난 후 지원자의 답변을 전문가 관점에서 평가합니다.
-                반드시 지정된 JSON 형식으로만 응답하세요.
-
                 [종합 점수]
                 overallScore는 전체 면접을 종합적으로 평가한 독립 점수입니다 (1~100).
                 전문가 점수의 단순 평균이 아니라, 면접 전반의 역량을 종합 판단하세요.
@@ -223,6 +223,7 @@ public class InterviewAiService {
 
         try {
             return chatClient.prompt()
+                    .advisors(AdvisorParams.ENABLE_NATIVE_STRUCTURED_OUTPUT)
                     .system(systemPrompt)
                     .user(userPrompt)
                     .call()
@@ -295,7 +296,8 @@ public class InterviewAiService {
 
     private record HistoryEntry(String role, String content) {}
 
-    private record KeywordCandidates(List<String> keywords) {}
+    private record KeywordCandidates(
+            @JsonProperty(required = true, value = "keywords") List<String> keywords) {}
 
     public List<String> extractKeywordCandidates(String selfIntroduction, String position) {
         String prompt = """
@@ -316,22 +318,20 @@ public class InterviewAiService {
                \s
                 3. 위 기준을 가장 잘 만족하는 키워드 3~5개를 선택한다.
                \s
-                코드 블록 없이 순수 JSON으로만 응답: {"keywords": ["...", ...]}
-
                 포지션: %s
                 자기소개: %s
                \s""".formatted(position, selfIntroduction);
+
         try {
-            String raw = chatClient.prompt()
+            KeywordCandidates result = chatClient.prompt()
+                    .advisors(AdvisorParams.ENABLE_NATIVE_STRUCTURED_OUTPUT)
                     .options(OpenAiChatOptions.builder()
                             .model(interviewAiProperties.getKeywordExtractionModel())
                             .temperature(interviewAiProperties.getKeywordExtractionTemperature())
                             .build())
                     .user(prompt)
                     .call()
-                    .content();
-            log.info("keyword extraction raw response: {}", raw);
-            KeywordCandidates result = objectMapper.readValue(raw, KeywordCandidates.class);
+                    .entity(KeywordCandidates.class);
             if (result.keywords() == null || result.keywords().isEmpty()) {
                 log.error("키워드 후보 추출 결과가 비어있음");
                 throw new BusinessException(ApiStatusCode.AI_SERVICE_ERROR);

--- a/src/main/java/app/mockly/domain/interview/service/InterviewAiService.java
+++ b/src/main/java/app/mockly/domain/interview/service/InterviewAiService.java
@@ -12,11 +12,11 @@ import app.mockly.global.exception.BusinessException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.ai.chat.client.ChatClient;
+import org.springframework.ai.openai.OpenAiChatOptions;
 import org.springframework.stereotype.Service;
 import reactor.core.publisher.Flux;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
 @Slf4j
 @Service
@@ -34,123 +34,38 @@ public class InterviewAiService {
         String position = session.getPosition();
         ExperienceLevel experienceLevel = session.getExperienceLevel();
         InterviewType interviewType = session.getInterviewType();
-        String selfIntroduction = session.getSelfIntroduction();
+        String keyword = session.getFirstQuestionKeyword();
         String systemPrompt = """
-                당신은 실제 기업에서 면접을 진행하는 숙련된 시니어 면접관입니다.
-
-                당신의 역할은 지원자의 "지식 수준"이 아니라,
-                "이해도, 사고 과정, 그리고 실무 적용 가능성"을 드러내는
-                첫 질문을 설계하는 것입니다.
+                당신은 기업 면접관입니다.
+                키워드 [%s]를 바탕으로 면접 첫 질문을 생성하세요.
+                출력: 면접관이 실제로 말로 읽을 수 있는 한 문장 질문
 
                 ---
-                [입력 정보]
-                - 지원 직무 (position)
-                - 경력 수준 (experienceLevel: JUNIOR / MID / SENIOR)
-                - 자기소개 (selfIntroduction 500자)
+                [질문 유형]
+                다음 6가지 유형 중 키워드와 경력 수준에 가장 적합한 하나를 선택하세요.
+                예시 문장을 그대로 사용하지 마세요.
+
+                1. 개념 확인형: 특정 기술이나 개념의 정의, 특징, 종류를 묻는다
+                   예시 스타일: "~이란 무엇인가요?"
+                2. 경험 회상형: 실제 경험과 그 과정, 결과를 묻는다
+                   예시 스타일: "~를 경험한 적이 있나요?"
+                3. 문제 해결형: 특정 문제를 어떻게 해결했는지 묻는다
+                   예시 스타일: "~ 상황을 어떻게 해결하셨나요?"
+                4. 설계형: 시스템 또는 구조 설계를 묻는다
+                   예시 스타일: "~를 어떻게 구성하셨나요?"
+                5. 트레이드오프형: 선택과 판단 기준을 묻는다
+                   예시 스타일: "A와 B 중 무엇을 선택하시겠습니까?"
+                6. 디버깅형: 문제 원인 분석과 탐색 과정을 묻는다
+                   예시 스타일: "문제를 어떤 순서로 파악하셨나요?"
 
                 ---
-                [핵심 목표]
-                좋은 첫 질문은 다음 조건을 만족해야 합니다:
-
-                1. 지원자가 실제로 답변할 수 있는 질문이어야 한다 (허황된 가정 금지)
-                2. 단순 암기 확인이 아니라 "이해 여부"가 드러나야 한다
-                3. 너무 포괄적이지 않고, 답변 범위가 적절히 제한되어 있어야 한다
-                4. 이후 꼬리 질문이 자연스럽게 이어질 수 있어야 한다
-
-                ---
-                [키워드 선택 전략 - 매우 중요]
-
-                1. 자기소개에서 기술/도메인 키워드 후보 3개를 추출한다.
-                   - 서로 다른 성격의 키워드를 선택할 것
-                     (예: 기술, 성능, 문제 해결 경험 등)
-
-                2. 각 키워드에 대해 아래 기준으로 평가한다:
-                   - 질문으로 만들었을 때 구체적인 답변이 가능한가?
-                   - 하나의 평가 포인트로 명확히 검증 가능한가?
-                   - 지원자의 경험 또는 이해도를 드러낼 수 있는가?
-
-                3. 위 기준을 가장 잘 만족하는 키워드 1개를 선택한다.
-
-                4. 선택한 키워드에 대해 A 또는 B 방식 중 더 적절한 방식으로 질문을 생성한다.
-
-                ---
-                [질문 생성 전략]
-                선택한 키워드 바탕으로 아래 두 가지 방식 중 하나로 질문을 생성한다:
-
-                [A. 개념 확인 질문] (기본)
-                - 해당 기술의 핵심 개념을 정확히 이해했는지 확인
-                - 정의 + 구조 + 동작 원리를 설명할 수 있는 질문
-
-                예:
-                - "트랜잭션이란 무엇인가요?"
-                - "영속성 컨텍스트가 어떤 역할을 하는지 설명해주실 수 있나요?"
-                - "Redis를 캐시로 사용할 때 어떤 자료구조를 사용하셨나요?"
-
-                [B. 제한된 상황 질문] (경력자 또는 경험이 드러난 경우)
-                - 실제 경험을 기반으로 판단/설계를 요구
-                - 단, 상황은 단순하고 명확해야 한다 (복잡한 시나리오 금지)
-
-                예:
-                - "트랜잭션을 사용하면서 롤백이 예상과 다르게 동작했던 경험이 있으신가요?"
-                - "JPA 사용 시 성능 문제가 발생했을 때 어떻게 접근하셨나요?"
-
-                ---
-                [경력 수준별 기준]
-
-                - JUNIOR:
-                  개념 이해 중심 (A 우선)
-                  → 정의 + 기본 동작 설명 가능한 질문
-                - MID:
-                  개념 + 경험 연결 (A 또는 B)
-                  → 실제 사용 경험이나 선택 이유
-                - SENIOR:
-                  설계 판단 중심 (B 우선)
-                  → trade-off, 설계 이유, 의사결정
-
-                ---
-                [출력 규칙]
-                - 반드시 질문 1문장만 생성한다.
-                - 인삿말 금지
-                - 불필요한 설명 금지
-                - "면접관:" 같은 접두사 금지
-                - "~도", "그리고" 등으로 질문을 이어붙이지 말 것
-                - 줄바꿈(\\n)을 사용하지 말고, 모든 내용을 한 줄로 출력할 것
-
-                ---
-                [금지 사항]
-                - 너무 추상적인 질문 (예: "시스템 설계 시 중요한 것은 무엇인가요?")
-                - 여러 개를 동시에 묻는 질문
-                - 답변 범위가 지나치게 넓은 질문
-                - 이론만 요구하거나, 경험만 강요하는 질문
-
-                ---
-                [강제 규칙]
-                - 하나의 질문에는 하나의 평가 포인트만 포함해야 한다
-                - "그리고", "~고", "~면서" 형태로 질문을 확장하지 말 것
-                - 개념 + 추가 해석(예: 데이터 일관성, 성능 영향 등)을 동시에 묻지 말 것
-                - 답변 범위가 명확히 떠오르지 않는 질문은 생성하지 말 것
-
-                ---
-                [키워드 선택 금지 규칙]
-                다음과 같은 추상적인 키워드는 선택하지 않는다:
-                - 데이터 일관성
-                - 성능
-                - 안정성
-                - 확장성
-                - 최적화
-
-                이러한 키워드는 반드시 더 구체적인 기술 또는 경험으로 변환해서 질문해야 한다.
-
-                [자기소개 기반성 규칙]
-
-                질문은 반드시 자기소개에 등장한 "구체적인 기술 또는 경험"에 직접 연결되어야 한다.
-
-                - 단순 개념 키워드만으로 질문하지 말 것
-                - 반드시 실제 사용한 기술 (예: JPA, Spring, Redis 등)을 중심으로 질문할 것
-
-
-                이 기준을 모두 만족하는, 가장 적절한 "첫 질문"을 생성하세요.
-                """;
+                [제약]
+                - 질문 소재는 키워드 [%s] 도메인에서 찾으세요. 자기소개에서 읽은 세부 내용을 질문 내용으로 삼지 마세요.
+                - 하나의 행동만 요구하는 질문을 생성하세요
+                  BAD: "Spring Boot와 JPA를 사용해 도메인을 구현한 뒤 조회 성능을 개선하기 위해 어떤 전략을 구성했나요?"
+                  GOOD: "JPA에서 N+1 문제를 어떻게 해결하셨나요?"
+                - 구체적이고 범위가 명확한 질문을 생성하세요
+                """.formatted(keyword, keyword);
 
         String userPrompt = """
                 다음 정보를 바탕으로 첫 번째 면접 질문을 생성하세요.
@@ -158,11 +73,13 @@ public class InterviewAiService {
                 - 포지션: %s
                 - 경력 수준: %s
                 - 면접 유형: %s
-                - 지원자 자기소개:
+                - [참고용] 지원자 자기소개:
                 \"\"\"
                 %s
                 \"\"\"
-                """.formatted(position, experienceLevel.getDescription(), interviewType.getDescription(), selfIntroduction);
+                - 탐색 키워드: %s
+                """.formatted(position, experienceLevel.getDescription(), interviewType.getDescription(),
+                        session.getSelfIntroduction(), keyword);
 
         try {
             return chatClient.prompt()
@@ -373,4 +290,55 @@ public class InterviewAiService {
     }
 
     private record HistoryEntry(String role, String content) {}
+
+    private record KeywordCandidates(List<String> keywords) {}
+
+    public List<String> extractKeywordCandidates(String selfIntroduction, String position) {
+        String prompt = """
+                1. 자기소개에서 기술/도메인 키워드 후보 7개를 추출한다.
+                   - 서로 다른 성격의 키워드를 선택할 것
+                     (예: 기술, 성능, 문제 해결 경험 등)
+                   - 기술명은 자기소개에 언급된 그대로 추출한다: "Spring Boot", "JPA", "Redis"
+                \s
+                BAD (추출 금지):
+                - "서비스 운영 중 발생한 문제 해결 경험" → 어떤 문제인지 불명확
+                - "이커머스 스타트업에서의 실무 경험" → 맥락 설명일 뿐
+                - "주문 도메인" → 기술도 경험도 아님
+
+                2. 각 키워드에 대해 아래 기준으로 평가한다:
+                   - 질문으로 만들었을 때 구체적인 답변이 가능한가?
+                   - 하나의 평가 포인트로 명확히 검증 가능한가?
+                   - 지원자의 경험 또는 이해도를 드러낼 수 있는가?
+               \s
+                3. 위 기준을 가장 잘 만족하는 키워드 3~5개를 선택한다.
+               \s
+                코드 블록 없이 순수 JSON으로만 응답: {"keywords": ["...", ...]}
+
+                포지션: %s
+                자기소개: %s
+               \s""".formatted(position, selfIntroduction);
+        try {
+            String raw = chatClient.prompt()
+                    .options(OpenAiChatOptions.builder()
+                            .model("gpt-4o-mini")
+                            .temperature(0.7)
+                            .build())
+                    .user(prompt)
+                    .call()
+                    .content();
+            log.info("keyword extraction raw response: {}", raw);
+            KeywordCandidates result = objectMapper.readValue(raw, KeywordCandidates.class);
+            if (result.keywords() == null || result.keywords().isEmpty()) {
+                log.error("키워드 후보 추출 결과가 비어있음");
+                throw new BusinessException(ApiStatusCode.AI_SERVICE_ERROR);
+            }
+            return result.keywords();
+        } catch (BusinessException e) {
+            throw e;
+        } catch (Exception e) {
+            log.error("키워드 후보 추출 실패", e);
+            throw new BusinessException(ApiStatusCode.AI_SERVICE_ERROR);
+        }
+    }
+
 }

--- a/src/main/java/app/mockly/domain/interview/service/InterviewService.java
+++ b/src/main/java/app/mockly/domain/interview/service/InterviewService.java
@@ -217,4 +217,14 @@ public class InterviewService {
             throw new BusinessException(ApiStatusCode.VALIDATION_ERROR, "현재 플랜에서 선택할 수 없는 질문 개수입니다.");
         }
     }
+
+    @Transactional
+    public void abandonSession(UUID userId, UUID sessionId) {
+        InterviewSession session = interviewSessionRepository.findByIdAndUserId(sessionId, userId)
+                .orElseThrow(() -> new BusinessException(ApiStatusCode.RESOURCE_NOT_FOUND));
+        if (!session.isInProgress()) {
+            throw new BusinessException(ApiStatusCode.VALIDATION_ERROR, "이미 종료된 면접 세션입니다.");
+        }
+        session.abandon();
+    }
 }

--- a/src/main/java/app/mockly/domain/interview/service/InterviewService.java
+++ b/src/main/java/app/mockly/domain/interview/service/InterviewService.java
@@ -7,6 +7,7 @@ import app.mockly.domain.interview.dto.request.CreateInterviewRequest;
 import app.mockly.domain.interview.dto.request.SubmitAnswerRequest;
 import app.mockly.domain.interview.dto.response.CreateInterviewResponse;
 import app.mockly.domain.interview.dto.response.FeedbackDto;
+import app.mockly.domain.interview.dto.response.GetQuotaResponse;
 import app.mockly.domain.interview.dto.response.GetSessionDetailResponse;
 import app.mockly.domain.interview.dto.response.GetSessionListResponse;
 import app.mockly.domain.interview.dto.response.SubmitAnswerResponse;
@@ -216,6 +217,29 @@ public class InterviewService {
         if (!allowed.contains(totalQuestions)) {
             throw new BusinessException(ApiStatusCode.VALIDATION_ERROR, "현재 플랜에서 선택할 수 없는 질문 개수입니다.");
         }
+    }
+
+    @Transactional(readOnly = true)
+    public GetQuotaResponse getQuota(UUID userId) {
+        PlanTier plan = getUserPlan(userId);
+        InterviewQuota quota = getQuota(plan);
+
+        ZoneId kst = ZoneId.of("Asia/Seoul");
+        ZonedDateTime startOfDay = LocalDate.now(kst).atStartOfDay(kst);
+        Instant startInstant = startOfDay.toInstant();
+        Instant endInstant = startOfDay.plusDays(1).toInstant();
+
+        long usedToday = interviewSessionRepository.countTodaySessions(userId, startInstant, endInstant);
+        return GetQuotaResponse.of(quota.getDailyLimit(), usedToday, quota.getMaxQuestionsPerSession());
+    }
+
+    @Transactional(readOnly = true)
+    public FeedbackDto getFeedback(UUID userId, UUID sessionId) {
+        interviewSessionRepository.findByIdAndUserId(sessionId, userId)
+                .orElseThrow(() -> new BusinessException(ApiStatusCode.RESOURCE_NOT_FOUND));
+        return interviewFeedbackRepository.findBySessionId(sessionId)
+                .map(f -> FeedbackDto.from(f, objectMapper))
+                .orElseThrow(() -> new BusinessException(ApiStatusCode.RESOURCE_NOT_FOUND, "아직 피드백이 생성되지 않은 세션입니다."));
     }
 
     @Transactional

--- a/src/main/java/app/mockly/domain/interview/service/InterviewService.java
+++ b/src/main/java/app/mockly/domain/interview/service/InterviewService.java
@@ -2,16 +2,11 @@ package app.mockly.domain.interview.service;
 
 import app.mockly.domain.auth.entity.User;
 import app.mockly.domain.auth.repository.UserRepository;
-import app.mockly.domain.interview.dto.InterviewFeedbackResult;
 import app.mockly.domain.interview.dto.QuestionStream;
 import app.mockly.domain.interview.dto.request.CreateInterviewRequest;
 import app.mockly.domain.interview.dto.request.SubmitAnswerRequest;
-import app.mockly.domain.interview.dto.response.CreateInterviewResponse;
-import app.mockly.domain.interview.dto.response.FeedbackDto;
-import app.mockly.domain.interview.dto.response.GetQuotaResponse;
-import app.mockly.domain.interview.dto.response.GetSessionDetailResponse;
-import app.mockly.domain.interview.dto.response.GetSessionListResponse;
-import app.mockly.domain.interview.dto.response.SubmitAnswerResponse;
+import app.mockly.domain.interview.dto.response.*;
+import app.mockly.domain.interview.event.FeedbackRequestedEvent;
 import app.mockly.domain.interview.entity.*;
 import app.mockly.domain.interview.repository.InterviewFeedbackRepository;
 import app.mockly.domain.interview.repository.InterviewMessageRepository;
@@ -25,6 +20,7 @@ import app.mockly.global.exception.BusinessException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Propagation;
@@ -61,6 +57,7 @@ public class InterviewService {
     private final InterviewQuotaRepository interviewQuotaRepository;
     private final InterviewSessionWriter interviewSessionWriter;
     private final ObjectMapper objectMapper;
+    private final ApplicationEventPublisher eventPublisher;
 
     public CreateInterviewResponse createSession(UUID userId, CreateInterviewRequest request) {
         User user = userRepository.findById(userId)
@@ -94,22 +91,9 @@ public class InterviewService {
                 InterviewMessage.createUserMessage(session, request.content(), session.getCurrentQuestionNumber()));
 
         if (session.isAllQuestionsAnswered()) {
-            PlanTier plan = getUserPlan(userId);
-            List<InterviewMessage> history = interviewMessageRepository.findBySessionIdOrderByIdAsc(sessionId);
-            InterviewFeedbackResult feedbackResult = interviewAiService.generateFeedback(
-                    history, session.getInterviewType(), plan);
-
-            session.complete();
-            interviewFeedbackRepository.save(InterviewFeedback.create(
-                    session,
-                    feedbackResult.overallScore(),
-                    serializeExpertFeedbacks(feedbackResult),
-                    feedbackResult.strengths(),
-                    feedbackResult.improvements(),
-                    feedbackResult.detailedAnalysis()
-            ));
-
-            return SubmitAnswerResponse.completed(session, feedbackResult);
+            session.startFeedbackGeneration();
+            eventPublisher.publishEvent(new FeedbackRequestedEvent(sessionId, userId));
+            return SubmitAnswerResponse.feedbackPending(session);
         }
 
         session.incrementQuestionNumber();
@@ -163,15 +147,6 @@ public class InterviewService {
         return GetSessionListResponse.from(result);
     }
 
-    private String serializeExpertFeedbacks(InterviewFeedbackResult result) {
-        try {
-            return objectMapper.writeValueAsString(result.expertFeedbacks());
-        } catch (Exception e) {
-            log.error("전문가 피드백 직렬화 실패", e);
-            return "[]";
-        }
-    }
-
     // active subscription이 있으면 PlanTier 반환, 없으면 FREE
     private PlanTier getUserPlan(UUID userId) {
         return subscriptionRepository.findByUserIdAndStatus(userId, SubscriptionStatus.ACTIVE)
@@ -223,12 +198,34 @@ public class InterviewService {
     }
 
     @Transactional(readOnly = true)
-    public FeedbackDto getFeedback(UUID userId, UUID sessionId) {
-        interviewSessionRepository.findByIdAndUserId(sessionId, userId)
+    public GetFeedbackResponse getFeedback(UUID userId, UUID sessionId) {
+        InterviewSession session = interviewSessionRepository.findByIdAndUserId(sessionId, userId)
                 .orElseThrow(() -> new BusinessException(ApiStatusCode.RESOURCE_NOT_FOUND));
-        return interviewFeedbackRepository.findBySessionId(sessionId)
+
+        FeedbackStatus feedbackStatus = session.getFeedbackStatus();
+        if (feedbackStatus == null) {
+            throw new BusinessException(ApiStatusCode.RESOURCE_NOT_FOUND, "아직 피드백이 생성되지 않은 세션입니다.");
+        }
+        if (feedbackStatus == FeedbackStatus.FAILED) {
+            return GetFeedbackResponse.failed(session.getFailReason());
+        }
+        if (feedbackStatus == FeedbackStatus.PENDING || feedbackStatus == FeedbackStatus.GENERATING) {
+            return GetFeedbackResponse.generating();
+        }
+        FeedbackDto feedback = interviewFeedbackRepository.findBySessionId(sessionId)
                 .map(f -> FeedbackDto.from(f, objectMapper))
-                .orElseThrow(() -> new BusinessException(ApiStatusCode.RESOURCE_NOT_FOUND, "아직 피드백이 생성되지 않은 세션입니다."));
+                .orElseThrow(() -> new BusinessException(ApiStatusCode.RESOURCE_NOT_FOUND, "피드백 데이터를 찾을 수 없습니다."));
+        return GetFeedbackResponse.completed(feedback);
+    }
+
+    @Transactional(readOnly = true)
+    public FeedbackStatusInfo getFeedbackStatusInfo(UUID userId, UUID sessionId) {
+        InterviewSession session = interviewSessionRepository.findByIdAndUserId(sessionId, userId)
+                .orElseThrow(() -> new BusinessException(ApiStatusCode.RESOURCE_NOT_FOUND));
+        if (session.getFeedbackStatus() == null) {
+            throw new BusinessException(ApiStatusCode.RESOURCE_NOT_FOUND, "피드백 생성이 시작되지 않은 세션입니다.");
+        }
+        return new FeedbackStatusInfo(session.getFeedbackStatus(), session.getFailReason());
     }
 
     @Transactional

--- a/src/main/java/app/mockly/domain/interview/service/InterviewService.java
+++ b/src/main/java/app/mockly/domain/interview/service/InterviewService.java
@@ -188,14 +188,14 @@ public class InterviewService {
                 .orElse(PlanTier.FREE);
     }
 
-    private InterviewQuota getQuota(PlanTier plan) {
+    private InterviewQuota getInterviewQuota(PlanTier plan) {
         return interviewQuotaRepository.findById(plan)
                 .orElseThrow(() -> new BusinessException(ApiStatusCode.RESOURCE_NOT_FOUND, "면접 쿼터 설정을 찾을 수 없습니다."));
     }
 
     // TODO: 추후 KST 기준을 User별 timezone 지원으로 확장
     private void validateQuota(UUID userId, PlanTier plan) {
-        int limit = getQuota(plan).getDailyLimit();
+        int limit = getInterviewQuota(plan).getDailyLimit();
 
         ZoneId kst = ZoneId.of("Asia/Seoul");
         ZonedDateTime startOfDay = LocalDate.now(kst).atStartOfDay(kst);
@@ -210,7 +210,7 @@ public class InterviewService {
 
     // preset {3,5,10} 중 플랜의 maxQuestionsPerSession 이하인 값만 허용
     private void validateQuestionCount(int totalQuestions, PlanTier plan) {
-        int max = getQuota(plan).getMaxQuestionsPerSession();
+        int max = getInterviewQuota(plan).getMaxQuestionsPerSession();
         Set<Integer> allowed = Set.of(3, 5, 10).stream()
                 .filter(q -> q <= max)
                 .collect(Collectors.toSet());
@@ -222,7 +222,7 @@ public class InterviewService {
     @Transactional(readOnly = true)
     public GetQuotaResponse getQuota(UUID userId) {
         PlanTier plan = getUserPlan(userId);
-        InterviewQuota quota = getQuota(plan);
+        InterviewQuota quota = getInterviewQuota(plan);
 
         ZoneId kst = ZoneId.of("Asia/Seoul");
         ZonedDateTime startOfDay = LocalDate.now(kst).atStartOfDay(kst);

--- a/src/main/java/app/mockly/domain/interview/service/InterviewService.java
+++ b/src/main/java/app/mockly/domain/interview/service/InterviewService.java
@@ -218,6 +218,24 @@ public class InterviewService {
         return GetFeedbackResponse.completed(feedback);
     }
 
+    @Transactional
+    public GetFeedbackResponse retryFeedback(UUID userId, UUID sessionId) {
+        // Assumption: no existing findSessionOrThrow helper was present; using the same ownership lookup pattern as existing methods.
+        InterviewSession session = interviewSessionRepository.findByIdAndUserId(sessionId, userId)
+                .orElseThrow(() -> new BusinessException(ApiStatusCode.RESOURCE_NOT_FOUND));
+
+        if (session.getFeedbackStatus() != FeedbackStatus.FAILED) {
+            throw new BusinessException(ApiStatusCode.VALIDATION_ERROR, "실패한 피드백만 재시도할 수 있습니다.");
+        }
+        if (session.getStatus() != InterviewSessionStatus.FEEDBACK_PENDING) {
+            throw new BusinessException(ApiStatusCode.VALIDATION_ERROR, "피드백 대기 상태인 세션만 재시도할 수 있습니다.");
+        }
+
+        session.resetFeedbackStatus();
+        eventPublisher.publishEvent(new FeedbackRequestedEvent(sessionId, userId));
+        return GetFeedbackResponse.pending();
+    }
+
     @Transactional(readOnly = true)
     public FeedbackStatusInfo getFeedbackStatusInfo(UUID userId, UUID sessionId) {
         InterviewSession session = interviewSessionRepository.findByIdAndUserId(sessionId, userId)

--- a/src/main/java/app/mockly/domain/interview/service/InterviewService.java
+++ b/src/main/java/app/mockly/domain/interview/service/InterviewService.java
@@ -3,6 +3,7 @@ package app.mockly.domain.interview.service;
 import app.mockly.domain.auth.entity.User;
 import app.mockly.domain.auth.repository.UserRepository;
 import app.mockly.domain.interview.dto.InterviewFeedbackResult;
+import app.mockly.domain.interview.dto.QuestionStream;
 import app.mockly.domain.interview.dto.request.CreateInterviewRequest;
 import app.mockly.domain.interview.dto.request.SubmitAnswerRequest;
 import app.mockly.domain.interview.dto.response.CreateInterviewResponse;
@@ -116,21 +117,21 @@ public class InterviewService {
     }
 
     @Transactional(readOnly = true)
-    public Flux<String> prepareQuestion(UUID sessionId, UUID userId) {
+    public QuestionStream getQuestionStream(UUID sessionId, UUID userId) {
         InterviewSession interviewSession = interviewSessionRepository.findByIdAndUserId(sessionId, userId)
                 .orElseThrow(() -> new BusinessException(ApiStatusCode.RESOURCE_NOT_FOUND));
         int questionNumber = interviewSession.getCurrentQuestionNumber();
 
         Optional<InterviewMessage> existing = interviewMessageRepository.findBySessionIdAndQuestionNumberAndRole(sessionId, questionNumber, InterviewMessageRole.INTERVIEWER);
         if (existing.isPresent()) {
-            return Flux.just(existing.get().getContent());
+            return new QuestionStream(questionNumber, Flux.just(existing.get().getContent()));
         }
 
-        if (questionNumber == 1) {
-            return interviewAiService.generateFirstQuestion(interviewSession);
-        }
-        List<InterviewMessage> history = interviewMessageRepository.findBySessionIdOrderByIdAsc(sessionId);
-        return interviewAiService.generateNextQuestion(interviewSession, history);
+        Flux<String> flux = questionNumber == 1
+                ? interviewAiService.generateFirstQuestion(interviewSession)
+                : interviewAiService.generateNextQuestion(interviewSession,
+                        interviewMessageRepository.findBySessionIdOrderByIdAsc(sessionId));
+        return new QuestionStream(questionNumber, flux);
     }
 
     @Transactional(propagation = Propagation.REQUIRES_NEW)
@@ -162,17 +163,11 @@ public class InterviewService {
         return GetSessionListResponse.from(result);
     }
 
-    @Transactional(readOnly = true)
-    public int getCurrentQuestionNumber(UUID sessionId, UUID userId) {
-        return interviewSessionRepository.findByIdAndUserId(sessionId, userId)
-                .orElseThrow(() -> new BusinessException(ApiStatusCode.RESOURCE_NOT_FOUND))
-                .getCurrentQuestionNumber();
-    }
-
     private String serializeExpertFeedbacks(InterviewFeedbackResult result) {
         try {
             return objectMapper.writeValueAsString(result.expertFeedbacks());
         } catch (Exception e) {
+            log.error("전문가 피드백 직렬화 실패", e);
             return "[]";
         }
     }
@@ -189,16 +184,19 @@ public class InterviewService {
                 .orElseThrow(() -> new BusinessException(ApiStatusCode.RESOURCE_NOT_FOUND, "면접 쿼터 설정을 찾을 수 없습니다."));
     }
 
-    // TODO: 추후 KST 기준을 User별 timezone 지원으로 확장
-    private void validateQuota(UUID userId, PlanTier plan) {
-        int limit = getInterviewQuota(plan).getDailyLimit();
+    // TODO: timezone 지원 시 TimeUtils 또는 TimeRangeProvider로 이전
+    private record TodayRange(Instant start, Instant end) {}
 
+    private TodayRange getTodayKstRange() {
         ZoneId kst = ZoneId.of("Asia/Seoul");
         ZonedDateTime startOfDay = LocalDate.now(kst).atStartOfDay(kst);
-        Instant startInstant = startOfDay.toInstant();
-        Instant endInstant = startOfDay.plusDays(1).toInstant();
+        return new TodayRange(startOfDay.toInstant(), startOfDay.plusDays(1).toInstant());
+    }
 
-        long todayCount = interviewSessionRepository.countTodaySessions(userId, startInstant, endInstant);
+    private void validateQuota(UUID userId, PlanTier plan) {
+        int limit = getInterviewQuota(plan).getDailyLimit();
+        TodayRange range = getTodayKstRange();
+        long todayCount = interviewSessionRepository.countTodaySessions(userId, range.start(), range.end());
         if (todayCount >= limit) {
             throw new BusinessException(ApiStatusCode.QUOTA_EXCEEDED);
         }
@@ -219,13 +217,8 @@ public class InterviewService {
     public GetQuotaResponse getQuota(UUID userId) {
         PlanTier plan = getUserPlan(userId);
         InterviewQuota quota = getInterviewQuota(plan);
-
-        ZoneId kst = ZoneId.of("Asia/Seoul");
-        ZonedDateTime startOfDay = LocalDate.now(kst).atStartOfDay(kst);
-        Instant startInstant = startOfDay.toInstant();
-        Instant endInstant = startOfDay.plusDays(1).toInstant();
-
-        long usedToday = interviewSessionRepository.countTodaySessions(userId, startInstant, endInstant);
+        TodayRange range = getTodayKstRange();
+        long usedToday = interviewSessionRepository.countTodaySessions(userId, range.start(), range.end());
         return GetQuotaResponse.of(quota.getDailyLimit(), usedToday, quota.getMaxQuestionsPerSession());
     }
 

--- a/src/main/java/app/mockly/domain/interview/service/InterviewService.java
+++ b/src/main/java/app/mockly/domain/interview/service/InterviewService.java
@@ -22,6 +22,7 @@ import app.mockly.global.common.ApiStatusCode;
 import app.mockly.global.exception.BusinessException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Propagation;
@@ -39,6 +40,7 @@ import java.time.ZonedDateTime;
 import java.util.*;
 import java.util.stream.Collectors;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class InterviewService {
@@ -69,6 +71,13 @@ public class InterviewService {
         InterviewSession session = InterviewSession.create(
                 user, request.position(), request.experienceLevel(), request.interviewType(),
                 request.totalQuestions(), request.selfIntroduction());
+
+        List<String> candidates = interviewAiService.extractKeywordCandidates(
+                request.selfIntroduction(), request.position());
+        log.info("keyword candidates: {}", candidates);
+        String keyword = candidates.get(RANDOM.nextInt(candidates.size()));
+        log.info("selected keyword: {}", keyword);
+        session.setFirstQuestionKeyword(keyword);
         interviewSessionRepository.save(session);
 
         session.incrementQuestionNumber();

--- a/src/main/java/app/mockly/domain/interview/service/InterviewService.java
+++ b/src/main/java/app/mockly/domain/interview/service/InterviewService.java
@@ -115,6 +115,7 @@ public class InterviewService {
         return SubmitAnswerResponse.inProgress(session);
     }
 
+    @Transactional(readOnly = true)
     public Flux<String> prepareQuestion(UUID sessionId, UUID userId) {
         InterviewSession interviewSession = interviewSessionRepository.findByIdAndUserId(sessionId, userId)
                 .orElseThrow(() -> new BusinessException(ApiStatusCode.RESOURCE_NOT_FOUND));
@@ -161,6 +162,7 @@ public class InterviewService {
         return GetSessionListResponse.from(result);
     }
 
+    @Transactional(readOnly = true)
     public int getCurrentQuestionNumber(UUID sessionId, UUID userId) {
         return interviewSessionRepository.findByIdAndUserId(sessionId, userId)
                 .orElseThrow(() -> new BusinessException(ApiStatusCode.RESOURCE_NOT_FOUND))

--- a/src/main/java/app/mockly/domain/interview/service/InterviewService.java
+++ b/src/main/java/app/mockly/domain/interview/service/InterviewService.java
@@ -58,9 +58,9 @@ public class InterviewService {
     private final SubscriptionRepository subscriptionRepository;
     private final InterviewAiService interviewAiService;
     private final InterviewQuotaRepository interviewQuotaRepository;
+    private final InterviewSessionWriter interviewSessionWriter;
     private final ObjectMapper objectMapper;
 
-    @Transactional
     public CreateInterviewResponse createSession(UUID userId, CreateInterviewRequest request) {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new BusinessException(ApiStatusCode.USER_NOT_FOUND));
@@ -69,19 +69,13 @@ public class InterviewService {
         validateQuota(userId, plan);
         validateQuestionCount(request.totalQuestions(), plan);
 
-        InterviewSession session = InterviewSession.create(
-                user, request.position(), request.experienceLevel(), request.interviewType(),
-                request.totalQuestions(), request.selfIntroduction());
-
         List<String> candidates = interviewAiService.extractKeywordCandidates(
                 request.selfIntroduction(), request.position());
         log.info("keyword candidates: {}", candidates);
         String keyword = candidates.get(RANDOM.nextInt(candidates.size()));
         log.info("selected keyword: {}", keyword);
-        session.setFirstQuestionKeyword(keyword);
-        interviewSessionRepository.save(session);
 
-        session.incrementQuestionNumber();
+        InterviewSession session = interviewSessionWriter.saveNewSession(user, request, keyword);
         String greeting = GREETINGS.get(RANDOM.nextInt(GREETINGS.size()));
         return CreateInterviewResponse.from(session, greeting);
     }

--- a/src/main/java/app/mockly/domain/interview/service/InterviewSessionWriter.java
+++ b/src/main/java/app/mockly/domain/interview/service/InterviewSessionWriter.java
@@ -1,0 +1,27 @@
+package app.mockly.domain.interview.service;
+
+import app.mockly.domain.auth.entity.User;
+import app.mockly.domain.interview.dto.request.CreateInterviewRequest;
+import app.mockly.domain.interview.entity.InterviewSession;
+import app.mockly.domain.interview.repository.InterviewSessionRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class InterviewSessionWriter {
+
+    private final InterviewSessionRepository interviewSessionRepository;
+
+    @Transactional
+    public InterviewSession saveNewSession(User user, CreateInterviewRequest request, String keyword) {
+        InterviewSession session = InterviewSession.create(
+                user, request.position(), request.experienceLevel(), request.interviewType(),
+                request.totalQuestions(), request.selfIntroduction());
+        session.setFirstQuestionKeyword(keyword);
+        interviewSessionRepository.save(session);
+        session.incrementQuestionNumber();
+        return session;
+    }
+}

--- a/src/main/java/app/mockly/domain/interview/service/MockInterviewAiService.java
+++ b/src/main/java/app/mockly/domain/interview/service/MockInterviewAiService.java
@@ -1,0 +1,52 @@
+package app.mockly.domain.interview.service;
+
+import app.mockly.domain.interview.dto.InterviewFeedbackResult;
+import app.mockly.domain.interview.entity.InterviewMessage;
+import app.mockly.domain.interview.entity.InterviewType;
+import app.mockly.domain.product.entity.PlanTier;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.micrometer.core.instrument.MeterRegistry;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.ai.chat.client.ChatClient;
+import org.springframework.context.annotation.Primary;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Service;
+
+import app.mockly.global.config.InterviewAiProperties;
+
+import java.util.List;
+
+@Slf4j
+@Service
+@Profile("loadtest")
+@Primary
+public class MockInterviewAiService extends InterviewAiService {
+
+    private static final long MOCK_DELAY_MS = 10_000;
+
+    public MockInterviewAiService(ChatClient.Builder chatClientBuilder, ObjectMapper objectMapper,
+                                  InterviewAiProperties interviewAiProperties, MeterRegistry meterRegistry) {
+        super(chatClientBuilder, objectMapper, interviewAiProperties, meterRegistry);
+    }
+
+    @Override
+    public InterviewFeedbackResult generateFeedback(List<InterviewMessage> history,
+                                                    InterviewType interviewType, PlanTier plan) {
+        log.info("[MOCK] generateFeedback 시작 — {}ms sleep", MOCK_DELAY_MS);
+        try {
+            Thread.sleep(MOCK_DELAY_MS);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+        log.info("[MOCK] generateFeedback 완료");
+
+        return new InterviewFeedbackResult(
+                75,
+                List.of(new InterviewFeedbackResult.ExpertFeedback(
+                        "기술 면접관", 75, "기본 개념을 잘 이해하고 있으며, 실무 경험을 바탕으로 답변했습니다.")),
+                "전반적으로 기술적 이해도가 좋습니다.",
+                "구체적인 사례를 더 활용하면 좋겠습니다.",
+                null
+        );
+    }
+}

--- a/src/main/java/app/mockly/domain/interview/service/StaleFeedbackRecoveryJob.java
+++ b/src/main/java/app/mockly/domain/interview/service/StaleFeedbackRecoveryJob.java
@@ -19,7 +19,7 @@ import java.util.List;
 @RequiredArgsConstructor
 public class StaleFeedbackRecoveryJob {
 
-    private static final int STALE_THRESHOLD_MINUTES = 5;
+    private static final int STALE_THRESHOLD_MINUTES = 6;
 
     private final InterviewSessionRepository interviewSessionRepository;
     private final ApplicationEventPublisher eventPublisher;

--- a/src/main/java/app/mockly/domain/interview/service/StaleFeedbackRecoveryJob.java
+++ b/src/main/java/app/mockly/domain/interview/service/StaleFeedbackRecoveryJob.java
@@ -4,6 +4,7 @@ import app.mockly.domain.interview.entity.FeedbackStatus;
 import app.mockly.domain.interview.entity.InterviewSession;
 import app.mockly.domain.interview.event.FeedbackRequestedEvent;
 import app.mockly.domain.interview.repository.InterviewSessionRepository;
+import app.mockly.global.config.InterviewFeedbackProperties;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.ApplicationEventPublisher;
@@ -19,15 +20,14 @@ import java.util.List;
 @RequiredArgsConstructor
 public class StaleFeedbackRecoveryJob {
 
-    private static final int STALE_THRESHOLD_MINUTES = 6;
-
     private final InterviewSessionRepository interviewSessionRepository;
     private final ApplicationEventPublisher eventPublisher;
+    private final InterviewFeedbackProperties interviewFeedbackProperties;
 
     @Scheduled(fixedDelay = 30_000)
     @Transactional
     public void recoverStaleFeedbacks() {
-        Instant threshold = Instant.now().minusSeconds(STALE_THRESHOLD_MINUTES * 60L);
+        Instant threshold = Instant.now().minusSeconds(interviewFeedbackProperties.getStaleThresholdMinutes() * 60L);
         List<InterviewSession> staleSessions = interviewSessionRepository
                 .findByFeedbackStatusInAndUpdatedAtBefore(
                         List.of(FeedbackStatus.PENDING, FeedbackStatus.GENERATING), threshold);

--- a/src/main/java/app/mockly/domain/interview/service/StaleFeedbackRecoveryJob.java
+++ b/src/main/java/app/mockly/domain/interview/service/StaleFeedbackRecoveryJob.java
@@ -1,0 +1,47 @@
+package app.mockly.domain.interview.service;
+
+import app.mockly.domain.interview.entity.FeedbackStatus;
+import app.mockly.domain.interview.entity.InterviewSession;
+import app.mockly.domain.interview.event.FeedbackRequestedEvent;
+import app.mockly.domain.interview.repository.InterviewSessionRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Instant;
+import java.util.List;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class StaleFeedbackRecoveryJob {
+
+    private static final int STALE_THRESHOLD_MINUTES = 5;
+
+    private final InterviewSessionRepository interviewSessionRepository;
+    private final ApplicationEventPublisher eventPublisher;
+
+    @Scheduled(fixedDelay = 30_000)
+    @Transactional
+    public void recoverStaleFeedbacks() {
+        Instant threshold = Instant.now().minusSeconds(STALE_THRESHOLD_MINUTES * 60L);
+        List<InterviewSession> staleSessions = interviewSessionRepository
+                .findByFeedbackStatusInAndUpdatedAtBefore(
+                        List.of(FeedbackStatus.PENDING, FeedbackStatus.GENERATING), threshold);
+
+        for (InterviewSession session : staleSessions) {
+            log.warn("stuck 피드백 복구: sessionId={}, feedbackStatus={}, updatedAt={}",
+                    session.getId(), session.getFeedbackStatus(), session.getUpdatedAt());
+            session.resetFeedbackStatus();
+            eventPublisher.publishEvent(
+                    new FeedbackRequestedEvent(session.getId(), session.getUser().getId()));
+        }
+
+        if (!staleSessions.isEmpty()) {
+            log.info("stuck 피드백 {}건 복구 완료", staleSessions.size());
+        }
+    }
+}

--- a/src/main/java/app/mockly/domain/payment/entity/OutboxEvent.java
+++ b/src/main/java/app/mockly/domain/payment/entity/OutboxEvent.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.persistence.*;
+import java.util.Map;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -47,7 +48,7 @@ public class OutboxEvent extends BaseEntity {
 
     public static OutboxEvent scheduleCreate(Long subscriptionId, String billingKey) {
         try {
-            var payloadMap = java.util.Map.of(
+            Map<String, Object> payloadMap = Map.of(
                     "subscriptionId", subscriptionId,
                     "billingKey", billingKey
             );

--- a/src/main/java/app/mockly/global/config/AsyncConfig.java
+++ b/src/main/java/app/mockly/global/config/AsyncConfig.java
@@ -1,0 +1,40 @@
+package app.mockly.global.config;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.aop.interceptor.AsyncUncaughtExceptionHandler;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.AsyncConfigurer;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+import java.util.concurrent.Executor;
+
+@Slf4j
+@Configuration
+@EnableAsync
+public class AsyncConfig implements AsyncConfigurer {
+
+    @Bean(name = "feedbackExecutor")
+    public Executor feedbackExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(5);
+        executor.setMaxPoolSize(10);
+        executor.setQueueCapacity(100);
+        executor.setThreadNamePrefix("feedback-");
+        // 거부 시 로그만 남김
+        // feedbackStatus는 PENDING 유지 → StaleFeedbackRecoveryJob이 30초 내 재처리
+        executor.setRejectedExecutionHandler((runnable, exec) ->
+                log.warn("feedbackExecutor rejected task. Will be recovered by scheduler."));
+        executor.setWaitForTasksToCompleteOnShutdown(true);
+        executor.setAwaitTerminationSeconds(60);
+        executor.initialize();
+        return executor;
+    }
+
+    @Override
+    public AsyncUncaughtExceptionHandler getAsyncUncaughtExceptionHandler() {
+        return (ex, method, params) ->
+                log.error("@Async 작업 예외 발생: method={}", method.getName(), ex);
+    }
+}

--- a/src/main/java/app/mockly/global/config/InterviewAiProperties.java
+++ b/src/main/java/app/mockly/global/config/InterviewAiProperties.java
@@ -1,0 +1,15 @@
+package app.mockly.global.config;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@Getter
+@Setter
+@Configuration
+@ConfigurationProperties("interview.ai")
+public class InterviewAiProperties {
+    private String keywordExtractionModel;
+    private double keywordExtractionTemperature;
+}

--- a/src/main/java/app/mockly/global/config/InterviewFeedbackProperties.java
+++ b/src/main/java/app/mockly/global/config/InterviewFeedbackProperties.java
@@ -1,0 +1,14 @@
+package app.mockly.global.config;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@Getter
+@Setter
+@Configuration
+@ConfigurationProperties("interview.feedback")
+public class InterviewFeedbackProperties {
+    private int staleThresholdMinutes = 6;
+}

--- a/src/main/java/app/mockly/global/config/LoadTestController.java
+++ b/src/main/java/app/mockly/global/config/LoadTestController.java
@@ -1,0 +1,22 @@
+package app.mockly.global.config;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Profile;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@Profile("loadtest")
+@RequiredArgsConstructor
+public class LoadTestController {
+
+    private final JdbcTemplate jdbcTemplate;
+
+    @GetMapping("/api/loadtest/db-ping")
+    public ResponseEntity<String> dbPing() {
+        jdbcTemplate.queryForObject("SELECT 1", Integer.class);
+        return ResponseEntity.ok("pong");
+    }
+}

--- a/src/main/java/app/mockly/global/config/LoadTestDataSeeder.java
+++ b/src/main/java/app/mockly/global/config/LoadTestDataSeeder.java
@@ -1,0 +1,129 @@
+package app.mockly.global.config;
+
+import app.mockly.domain.auth.entity.OAuth2Provider;
+import app.mockly.domain.auth.entity.User;
+import app.mockly.domain.auth.repository.UserRepository;
+import app.mockly.domain.auth.service.JwtService;
+import app.mockly.domain.interview.entity.ExperienceLevel;
+import app.mockly.domain.interview.entity.InterviewMessage;
+import app.mockly.domain.interview.entity.InterviewQuota;
+import app.mockly.domain.interview.entity.InterviewSession;
+import app.mockly.domain.interview.entity.InterviewType;
+import app.mockly.domain.interview.repository.InterviewMessageRepository;
+import app.mockly.domain.interview.repository.InterviewQuotaRepository;
+import app.mockly.domain.interview.repository.InterviewSessionRepository;
+import app.mockly.domain.product.entity.PlanTier;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+
+import java.io.FileWriter;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+@Slf4j
+@Component
+@Profile("loadtest")
+@RequiredArgsConstructor
+public class LoadTestDataSeeder implements ApplicationRunner {
+
+    private static final int USER_COUNT = 30;
+    private static final int SESSIONS_PER_USER = 300;
+
+    private final UserRepository userRepository;
+    private final InterviewSessionRepository interviewSessionRepository;
+    private final InterviewMessageRepository interviewMessageRepository;
+    private final InterviewQuotaRepository interviewQuotaRepository;
+    private final JwtService jwtService;
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public void run(ApplicationArguments args) throws Exception {
+        log.info("[LoadTest] 데이터 시딩 시작 — {} 사용자 × {} 세션", USER_COUNT, SESSIONS_PER_USER);
+
+        seedQuota();
+
+        List<Map<String, Object>> fixtures = new ArrayList<>();
+
+        for (int i = 0; i < USER_COUNT; i++) {
+            User user = createUser(i);
+            String token = jwtService.generateAccessToken(user.getId());
+
+            List<String> sessionIds = new ArrayList<>();
+            for (int j = 0; j < SESSIONS_PER_USER; j++) {
+                InterviewSession session = createSession(user);
+                createMessages(session);
+                sessionIds.add(session.getId().toString());
+            }
+
+            fixtures.add(Map.of(
+                    "userId", user.getId().toString(),
+                    "token", token,
+                    "sessionIds", sessionIds
+            ));
+        }
+
+        String json = objectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(fixtures);
+        try (FileWriter writer = new FileWriter("loadtest-fixtures.json")) {
+            writer.write(json);
+        }
+
+        log.info("[LoadTest] 데이터 시딩 완료 — {} 세션 생성, loadtest-fixtures.json 출력", USER_COUNT * SESSIONS_PER_USER);
+    }
+
+    private void seedQuota() {
+        if (interviewQuotaRepository.findById(PlanTier.FREE).isEmpty()) {
+            interviewQuotaRepository.save(InterviewQuota.builder()
+                    .planTier(PlanTier.FREE)
+                    .dailyLimit(5)
+                    .maxQuestionsPerSession(3)
+                    .build());
+        }
+    }
+
+    private User createUser(int index) {
+        User user = User.builder()
+                .provider(OAuth2Provider.GOOGLE)
+                .providerId("loadtest-" + index)
+                .email("loadtest-" + index + "@test.com")
+                .name("LoadTestUser" + index)
+                .build();
+        return userRepository.save(user);
+    }
+
+    private InterviewSession createSession(User user) {
+        InterviewSession session = InterviewSession.builder()
+                .user(user)
+                .position("백엔드 개발자")
+                .selfIntroduction("Spring Boot와 JPA를 활용한 서버 개발 경험이 있습니다.")
+                .experienceLevel(ExperienceLevel.JUNIOR)
+                .interviewType(InterviewType.TECHNICAL)
+                .totalQuestions(3)
+                .currentQuestionNumber(3)
+                .status(app.mockly.domain.interview.entity.InterviewSessionStatus.IN_PROGRESS)
+                .firstQuestionKeyword("Spring Boot")
+                .build();
+        return interviewSessionRepository.save(session);
+    }
+
+    private void createMessages(InterviewSession session) {
+        List<InterviewMessage> messages = List.of(
+                InterviewMessage.createInterviewerMessage(session,
+                        "Spring Boot에서 의존성 주입이란 무엇인가요?", 1),
+                InterviewMessage.createUserMessage(session,
+                        "의존성 주입은 객체가 필요한 의존 객체를 외부에서 주입받는 패턴입니다.", 1),
+                InterviewMessage.createInterviewerMessage(session,
+                        "생성자 주입이 권장되는 이유는 무엇인가요?", 2),
+                InterviewMessage.createUserMessage(session,
+                        "불변성을 보장하고 순환 참조를 컴파일 타임에 발견할 수 있기 때문입니다.", 2),
+                InterviewMessage.createInterviewerMessage(session,
+                        "순환 참조를 구조적으로 해결하는 방법은 무엇이 있나요?", 3)
+        );
+        interviewMessageRepository.saveAll(messages);
+    }
+}

--- a/src/main/java/app/mockly/global/config/OpenAiConfig.java
+++ b/src/main/java/app/mockly/global/config/OpenAiConfig.java
@@ -1,0 +1,25 @@
+package app.mockly.global.config;
+
+import org.springframework.boot.http.client.ClientHttpRequestFactoryBuilder;
+import org.springframework.boot.http.client.ClientHttpRequestFactorySettings;
+import org.springframework.boot.web.client.RestClientCustomizer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.time.Duration;
+
+@Configuration
+public class OpenAiConfig {
+
+    private static final Duration CONNECT_TIMEOUT = Duration.ofSeconds(10);
+    private static final Duration READ_TIMEOUT = Duration.ofSeconds(60);
+
+    @Bean
+    public RestClientCustomizer openAiRestClientCustomizer() {
+        ClientHttpRequestFactorySettings settings = ClientHttpRequestFactorySettings.defaults()
+                .withConnectTimeout(CONNECT_TIMEOUT)
+                .withReadTimeout(READ_TIMEOUT);
+        return builder -> builder.requestFactory(
+                ClientHttpRequestFactoryBuilder.detect().build(settings));
+    }
+}

--- a/src/main/java/app/mockly/global/config/SecurityConfig.java
+++ b/src/main/java/app/mockly/global/config/SecurityConfig.java
@@ -39,7 +39,8 @@ public class SecurityConfig {
                         "/swagger-ui.html",
                         "/openapi3.yaml",
                         "/actuator/health",
-                        "/actuator/prometheus"
+                        "/actuator/prometheus",
+                        "/api/loadtest/**"
                 )
                 .csrf(AbstractHttpConfigurer::disable)
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))

--- a/src/main/java/app/mockly/global/config/SecurityConfig.java
+++ b/src/main/java/app/mockly/global/config/SecurityConfig.java
@@ -37,7 +37,9 @@ public class SecurityConfig {
                         "/swagger-ui/**",
                         "/v3/api-docs/**",
                         "/swagger-ui.html",
-                        "/openapi3.yaml"
+                        "/openapi3.yaml",
+                        "/actuator/health",
+                        "/actuator/prometheus"
                 )
                 .csrf(AbstractHttpConfigurer::disable)
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -59,6 +59,11 @@ spring.ai:
         model: gpt-5.4-nano
         temperature: 1.0
 
+interview:
+  ai:
+    keyword-extraction-model: gpt-4o-mini
+    keyword-extraction-temperature: 0.7
+
 portone:
   api-secret: ${PORTONE_API_SECRET}
   api-base: https://api.portone.io

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -64,6 +64,15 @@ interview:
     keyword-extraction-model: gpt-4o-mini
     keyword-extraction-temperature: 0.7
 
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health, prometheus
+  metrics:
+    tags:
+      application: mockly
+
 portone:
   api-secret: ${PORTONE_API_SECRET}
   api-base: https://api.portone.io

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -54,7 +54,9 @@ spring.ai:
     api-key: ${OPENAI_API_KEY}
     chat:
       options:
-        model: gpt-5-mini
+#        model: gpt-4o-mini
+#        temperature: 0.9
+        model: gpt-5.4-nano
         temperature: 1.0
 
 portone:

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -66,6 +66,8 @@ interview:
   ai:
     keyword-extraction-model: gpt-4o-mini
     keyword-extraction-temperature: 0.7
+  feedback:
+    stale-threshold-minutes: ${INTERVIEW_FEEDBACK_STALE_THRESHOLD_MINUTES:6}
 
 management:
   endpoints:

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -7,6 +7,9 @@ spring:
     username: ${POSTGRES_USER}
     password: ${POSTGRES_PASSWORD}
     driver-class-name: org.postgresql.Driver
+    hikari:
+      connection-timeout: 5000   # 5s — 실시간 API 서버 권장값. pool 고갈 시 빠르게 실패
+      keepalive-time: 120000     # 2분 — NAT/방화벽 idle timeout(AWS 350s)보다 짧게 유지
 
   # JPA 설정
   jpa:

--- a/src/test/java/app/mockly/domain/interview/controller/InterviewControllerTest.java
+++ b/src/test/java/app/mockly/domain/interview/controller/InterviewControllerTest.java
@@ -7,6 +7,8 @@ import app.mockly.domain.auth.service.JwtService;
 import app.mockly.domain.auth.service.TokenBlacklistService;
 import app.mockly.domain.interview.controller.docs.AbandonSessionDocs;
 import app.mockly.domain.interview.controller.docs.CreateInterviewDocs;
+import app.mockly.domain.interview.controller.docs.FeedbackDocs;
+import app.mockly.domain.interview.controller.docs.QuotaDocs;
 import app.mockly.domain.interview.controller.docs.SessionDetailDocs;
 import app.mockly.domain.interview.controller.docs.SessionListDocs;
 import app.mockly.domain.interview.controller.docs.StreamQuestionDocs;
@@ -15,12 +17,14 @@ import app.mockly.domain.interview.dto.InterviewFeedbackResult;
 import app.mockly.domain.interview.dto.request.CreateInterviewRequest;
 import app.mockly.domain.interview.dto.request.SubmitAnswerRequest;
 import app.mockly.domain.interview.entity.ExperienceLevel;
+import app.mockly.domain.interview.entity.InterviewFeedback;
 import app.mockly.domain.interview.entity.InterviewMessage;
 import app.mockly.domain.interview.entity.InterviewQuota;
 import app.mockly.domain.interview.entity.InterviewSession;
 import app.mockly.domain.interview.entity.InterviewSessionStatus;
 import app.mockly.domain.interview.entity.InterviewType;
 import reactor.core.publisher.Flux;
+import app.mockly.domain.interview.repository.InterviewFeedbackRepository;
 import app.mockly.domain.interview.repository.InterviewMessageRepository;
 import app.mockly.domain.interview.repository.InterviewQuotaRepository;
 import app.mockly.domain.interview.repository.InterviewSessionRepository;
@@ -85,6 +89,9 @@ class InterviewControllerTest {
 
     @Autowired
     private InterviewSessionRepository interviewSessionRepository;
+
+    @Autowired
+    private InterviewFeedbackRepository interviewFeedbackRepository;
 
     @Autowired
     private InterviewMessageRepository interviewMessageRepository;
@@ -398,6 +405,81 @@ class InterviewControllerTest {
                 .andExpect(jsonPath("$.success").value(false))
                 .andDo(document("interview-create-unauthorized",
                         resource(CreateInterviewDocs.unauthorized())
+                ));
+    }
+
+    @Test
+    @DisplayName("GET /api/interviews/quota - 성공: FREE 플랜 쿼터 조회")
+    void getQuota_success() throws Exception {
+        mockMvc.perform(get("/api/interviews/quota")
+                        .header("Authorization", "Bearer " + validAccessToken))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.dailyLimit").value(1))
+                .andExpect(jsonPath("$.data.usedToday").value(0))
+                .andExpect(jsonPath("$.data.remaining").value(1))
+                .andExpect(jsonPath("$.data.maxQuestionsPerSession").value(3))
+                .andDo(document("interview-get-quota",
+                        resource(QuotaDocs.success())
+                ));
+    }
+
+    @Test
+    @DisplayName("GET /api/interviews/quota - 성공: 오늘 세션 사용 후 남은 쿼터 조회")
+    void getQuota_afterUsed() throws Exception {
+        interviewSessionRepository.save(InterviewSession.create(
+                testUser, "백엔드 개발자", ExperienceLevel.JUNIOR, InterviewType.TECHNICAL, 3,
+                "1년차 백엔드 개발자입니다."
+        ));
+
+        mockMvc.perform(get("/api/interviews/quota")
+                        .header("Authorization", "Bearer " + validAccessToken))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.usedToday").value(1))
+                .andExpect(jsonPath("$.data.remaining").value(0));
+    }
+
+    @Test
+    @DisplayName("GET /api/interviews/:sessionId/feedback - 성공: 피드백 조회")
+    void getFeedback_success() throws Exception {
+        InterviewSession session = saveSession(3, 3, InterviewSessionStatus.COMPLETED);
+        interviewFeedbackRepository.save(InterviewFeedback.create(
+                session, 80,
+                "[{\"expertRole\":\"기술 면접관\",\"score\":80,\"evaluation\":\"전반적으로 좋습니다.\"}]",
+                "논리적인 답변 구조",
+                "더 구체적인 사례 제시 필요",
+                null
+        ));
+
+        mockMvc.perform(get("/api/interviews/{sessionId}/feedback", session.getId())
+                        .header("Authorization", "Bearer " + validAccessToken))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.overallScore").value(80))
+                .andExpect(jsonPath("$.data.expertFeedbacks[0].expertRole").value("기술 면접관"))
+                .andExpect(jsonPath("$.data.strengths").value("논리적인 답변 구조"))
+                .andExpect(jsonPath("$.data.improvements").value("더 구체적인 사례 제시 필요"))
+                .andDo(document("interview-get-feedback",
+                        resource(FeedbackDocs.success())
+                ));
+    }
+
+    @Test
+    @DisplayName("GET /api/interviews/:sessionId/feedback - 실패: 피드백 없음 (404)")
+    void getFeedback_notFound() throws Exception {
+        InterviewSession session = saveSession(1, 3, InterviewSessionStatus.IN_PROGRESS);
+
+        mockMvc.perform(get("/api/interviews/{sessionId}/feedback", session.getId())
+                        .header("Authorization", "Bearer " + validAccessToken))
+                .andDo(print())
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.error").value("RESOURCE_NOT_FOUND"))
+                .andDo(document("interview-get-feedback-not-found",
+                        resource(FeedbackDocs.notFound())
                 ));
     }
 

--- a/src/test/java/app/mockly/domain/interview/controller/InterviewControllerTest.java
+++ b/src/test/java/app/mockly/domain/interview/controller/InterviewControllerTest.java
@@ -5,6 +5,7 @@ import app.mockly.domain.auth.entity.User;
 import app.mockly.domain.auth.repository.UserRepository;
 import app.mockly.domain.auth.service.JwtService;
 import app.mockly.domain.auth.service.TokenBlacklistService;
+import app.mockly.domain.interview.controller.docs.AbandonSessionDocs;
 import app.mockly.domain.interview.controller.docs.CreateInterviewDocs;
 import app.mockly.domain.interview.controller.docs.SessionDetailDocs;
 import app.mockly.domain.interview.controller.docs.SessionListDocs;
@@ -46,6 +47,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.patch;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
@@ -396,6 +398,38 @@ class InterviewControllerTest {
                 .andExpect(jsonPath("$.success").value(false))
                 .andDo(document("interview-create-unauthorized",
                         resource(CreateInterviewDocs.unauthorized())
+                ));
+    }
+
+    @Test
+    @DisplayName("PATCH /api/interviews/:sessionId/abandon - 성공: 세션 포기")
+    void abandonSession_success() throws Exception {
+        InterviewSession session = saveSession(1, 3, InterviewSessionStatus.IN_PROGRESS);
+
+        mockMvc.perform(patch("/api/interviews/{sessionId}/abandon", session.getId())
+                        .header("Authorization", "Bearer " + validAccessToken))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data").doesNotExist())
+                .andDo(document("interview-abandon-session",
+                        resource(AbandonSessionDocs.success())
+                ));
+    }
+
+    @Test
+    @DisplayName("PATCH /api/interviews/:sessionId/abandon - 실패: 이미 완료된 세션 (400)")
+    void abandonSession_alreadyCompleted() throws Exception {
+        InterviewSession session = saveSession(3, 3, InterviewSessionStatus.COMPLETED);
+
+        mockMvc.perform(patch("/api/interviews/{sessionId}/abandon", session.getId())
+                        .header("Authorization", "Bearer " + validAccessToken))
+                .andDo(print())
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.error").value("VALIDATION_ERROR"))
+                .andDo(document("interview-abandon-session-already-completed",
+                        resource(AbandonSessionDocs.alreadyCompleted())
                 ));
     }
 

--- a/src/test/java/app/mockly/domain/interview/controller/InterviewControllerTest.java
+++ b/src/test/java/app/mockly/domain/interview/controller/InterviewControllerTest.java
@@ -102,6 +102,8 @@ class InterviewControllerTest {
         validAccessToken = jwtService.generateAccessToken(testUser.getId());
 
         given(tokenBlacklistService.isBlacklisted(anyString())).willReturn(false);
+        given(interviewAiService.extractKeywordCandidates(anyString(), anyString()))
+                .willReturn(List.of("JPA", "Spring Boot", "REST API"));
         given(interviewAiService.generateFirstQuestion(any(app.mockly.domain.interview.entity.InterviewSession.class)))
                 .willReturn(Flux.just("자기소개를 해주세요."));
         given(interviewAiService.generateNextQuestion(any(app.mockly.domain.interview.entity.InterviewSession.class), any()))

--- a/src/test/java/app/mockly/domain/interview/controller/InterviewControllerTest.java
+++ b/src/test/java/app/mockly/domain/interview/controller/InterviewControllerTest.java
@@ -30,8 +30,10 @@ import app.mockly.domain.interview.repository.InterviewFeedbackRepository;
 import app.mockly.domain.interview.repository.InterviewMessageRepository;
 import app.mockly.domain.interview.repository.InterviewQuotaRepository;
 import app.mockly.domain.interview.repository.InterviewSessionRepository;
+import app.mockly.domain.interview.service.FeedbackSseManager;
 import app.mockly.domain.interview.service.InterviewAiService;
 import app.mockly.domain.product.entity.PlanTier;
+import app.mockly.global.exception.BusinessException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -44,14 +46,20 @@ import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 import static com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper.document;
 import static com.epages.restdocs.apispec.ResourceDocumentation.resource;
 import java.util.List;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.patch;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
@@ -82,6 +90,9 @@ class InterviewControllerTest {
 
     @MockitoBean
     private InterviewAiService interviewAiService;
+
+    @MockitoBean
+    private FeedbackSseManager feedbackSseManager;
 
     @Autowired
     private UserRepository userRepository;
@@ -486,6 +497,35 @@ class InterviewControllerTest {
                 .andDo(document("interview-get-feedback-not-found",
                         resource(FeedbackDocs.notFound())
                 ));
+    }
+
+    @Test
+    @DisplayName("GET /api/interviews/:sessionId/feedback/events - 실패: 세션 없음이면 SSE 연결을 등록하지 않음")
+    void feedbackEvents_sessionNotFound_doesNotConnectEmitter() throws Exception {
+        assertThatThrownBy(() -> mockMvc.perform(get("/api/interviews/{sessionId}/feedback/events", java.util.UUID.randomUUID())
+                        .header("Authorization", "Bearer " + validAccessToken)
+                        .accept(MediaType.TEXT_EVENT_STREAM)))
+                .hasRootCauseInstanceOf(BusinessException.class);
+
+        verify(feedbackSseManager, never()).connect(any(), anyLong());
+    }
+
+    @Test
+    @DisplayName("GET /api/interviews/:sessionId/feedback/events - 성공: 완료 상태면 fallback 이벤트 전송 후 종료")
+    void feedbackEvents_completed_sendsFallbackAndCompletes() throws Exception {
+        InterviewSession session = saveSession(3, 3, InterviewSessionStatus.COMPLETED, FeedbackStatus.COMPLETED);
+        SseEmitter emitter = new SseEmitter(60_000L);
+        given(feedbackSseManager.connect(eq(session.getId()), eq(60_000L))).willReturn(emitter);
+
+        mockMvc.perform(get("/api/interviews/{sessionId}/feedback/events", session.getId())
+                        .header("Authorization", "Bearer " + validAccessToken)
+                        .accept(MediaType.TEXT_EVENT_STREAM))
+                .andExpect(request().asyncStarted())
+                .andReturn();
+
+        verify(feedbackSseManager).connect(session.getId(), 60_000L);
+        verify(feedbackSseManager).send(session.getId(), FeedbackStatus.COMPLETED, null);
+        verify(feedbackSseManager).complete(session.getId());
     }
 
     @Test

--- a/src/test/java/app/mockly/domain/interview/controller/InterviewControllerTest.java
+++ b/src/test/java/app/mockly/domain/interview/controller/InterviewControllerTest.java
@@ -21,6 +21,7 @@ import app.mockly.domain.interview.entity.InterviewFeedback;
 import app.mockly.domain.interview.entity.InterviewMessage;
 import app.mockly.domain.interview.entity.InterviewQuota;
 import app.mockly.domain.interview.entity.InterviewSession;
+import app.mockly.domain.interview.entity.FeedbackStatus;
 import app.mockly.domain.interview.entity.InterviewSessionStatus;
 import app.mockly.domain.interview.entity.InterviewType;
 import reactor.core.publisher.Flux;
@@ -229,7 +230,7 @@ class InterviewControllerTest {
                 .andDo(print())
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.success").value(true))
-                .andExpect(jsonPath("$.data.isCompleted").value(false))
+                .andExpect(jsonPath("$.data.sessionStatus").value("IN_PROGRESS"))
                 .andExpect(jsonPath("$.data.currentQuestionNumber").value(2))
                 .andDo(document("interview-submit-answer",
                         resource(SubmitAnswerDocs.success())
@@ -237,8 +238,8 @@ class InterviewControllerTest {
     }
 
     @Test
-    @DisplayName("POST /api/interviews/:sessionId/answer - 성공: 마지막 답변, 피드백 반환")
-    void submitAnswer_completed() throws Exception {
+    @DisplayName("POST /api/interviews/:sessionId/answer - 성공: 마지막 답변, 피드백 대기 상태 반환")
+    void submitAnswer_feedbackPending() throws Exception {
         InterviewSession session = saveSession(3, 3, InterviewSessionStatus.IN_PROGRESS);
         SubmitAnswerRequest request = new SubmitAnswerRequest("마지막 질문에 대한 답변입니다.");
 
@@ -249,13 +250,10 @@ class InterviewControllerTest {
                 .andDo(print())
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.success").value(true))
-                .andExpect(jsonPath("$.data.isCompleted").value(true))
-
-                .andExpect(jsonPath("$.data.feedback.overallScore").value(75))
-                .andExpect(jsonPath("$.data.feedback.expertFeedbacks[0].expertRole").value("기술 면접관"))
-                .andExpect(jsonPath("$.data.feedback.expertFeedbacks[0].score").value(75))
-                .andDo(document("interview-submit-answer-completed",
-                        resource(SubmitAnswerDocs.successCompleted())
+                .andExpect(jsonPath("$.data.sessionStatus").value("FEEDBACK_PENDING"))
+                .andExpect(jsonPath("$.data.feedback").doesNotExist())
+                .andDo(document("interview-submit-answer-feedback-pending",
+                        resource(SubmitAnswerDocs.feedbackPending())
                 ));
     }
 
@@ -336,6 +334,10 @@ class InterviewControllerTest {
     }
 
     private InterviewSession saveSession(int currentQuestionNumber, int totalQuestions, InterviewSessionStatus status) {
+        return saveSession(currentQuestionNumber, totalQuestions, status, null);
+    }
+
+    private InterviewSession saveSession(int currentQuestionNumber, int totalQuestions, InterviewSessionStatus status, FeedbackStatus feedbackStatus) {
         return interviewSessionRepository.save(
                 InterviewSession.builder()
                         .user(testUser)
@@ -346,6 +348,7 @@ class InterviewControllerTest {
                         .selfIntroduction("1년차 백엔드 개발자로 이커머스 서비스를 개발했습니다.")
                         .currentQuestionNumber(currentQuestionNumber)
                         .status(status)
+                        .feedbackStatus(feedbackStatus)
                         .build()
         );
     }
@@ -444,7 +447,7 @@ class InterviewControllerTest {
     @Test
     @DisplayName("GET /api/interviews/:sessionId/feedback - 성공: 피드백 조회")
     void getFeedback_success() throws Exception {
-        InterviewSession session = saveSession(3, 3, InterviewSessionStatus.COMPLETED);
+        InterviewSession session = saveSession(3, 3, InterviewSessionStatus.COMPLETED, FeedbackStatus.COMPLETED);
         interviewFeedbackRepository.save(InterviewFeedback.create(
                 session, 80,
                 "[{\"expertRole\":\"기술 면접관\",\"score\":80,\"evaluation\":\"전반적으로 좋습니다.\"}]",
@@ -458,10 +461,11 @@ class InterviewControllerTest {
                 .andDo(print())
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.success").value(true))
-                .andExpect(jsonPath("$.data.overallScore").value(80))
-                .andExpect(jsonPath("$.data.expertFeedbacks[0].expertRole").value("기술 면접관"))
-                .andExpect(jsonPath("$.data.strengths").value("논리적인 답변 구조"))
-                .andExpect(jsonPath("$.data.improvements").value("더 구체적인 사례 제시 필요"))
+                .andExpect(jsonPath("$.data.feedbackStatus").value("COMPLETED"))
+                .andExpect(jsonPath("$.data.feedback.overallScore").value(80))
+                .andExpect(jsonPath("$.data.feedback.expertFeedbacks[0].expertRole").value("기술 면접관"))
+                .andExpect(jsonPath("$.data.feedback.strengths").value("논리적인 답변 구조"))
+                .andExpect(jsonPath("$.data.feedback.improvements").value("더 구체적인 사례 제시 필요"))
                 .andDo(document("interview-get-feedback",
                         resource(FeedbackDocs.success())
                 ));

--- a/src/test/java/app/mockly/domain/interview/controller/InterviewControllerTest.java
+++ b/src/test/java/app/mockly/domain/interview/controller/InterviewControllerTest.java
@@ -9,6 +9,7 @@ import app.mockly.domain.interview.controller.docs.AbandonSessionDocs;
 import app.mockly.domain.interview.controller.docs.CreateInterviewDocs;
 import app.mockly.domain.interview.controller.docs.FeedbackDocs;
 import app.mockly.domain.interview.controller.docs.QuotaDocs;
+import app.mockly.domain.interview.controller.docs.RetryFeedbackDocs;
 import app.mockly.domain.interview.controller.docs.SessionDetailDocs;
 import app.mockly.domain.interview.controller.docs.SessionListDocs;
 import app.mockly.domain.interview.controller.docs.StreamQuestionDocs;
@@ -484,6 +485,53 @@ class InterviewControllerTest {
                 .andExpect(jsonPath("$.error").value("RESOURCE_NOT_FOUND"))
                 .andDo(document("interview-get-feedback-not-found",
                         resource(FeedbackDocs.notFound())
+                ));
+    }
+
+    @Test
+    @DisplayName("POST /api/interviews/:sessionId/feedback/retry - 성공: 실패한 피드백 재시도")
+    void retryFeedback_success() throws Exception {
+        InterviewSession session = saveSession(3, 3, InterviewSessionStatus.FEEDBACK_PENDING, FeedbackStatus.FAILED);
+
+        mockMvc.perform(post("/api/interviews/{sessionId}/feedback/retry", session.getId())
+                        .header("Authorization", "Bearer " + validAccessToken))
+                .andDo(print())
+                .andExpect(status().isAccepted())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.feedbackStatus").value("PENDING"))
+                .andExpect(jsonPath("$.data.feedback").doesNotExist())
+                .andDo(document("interview-retry-feedback",
+                        resource(RetryFeedbackDocs.success())
+                ));
+    }
+
+    @Test
+    @DisplayName("POST /api/interviews/:sessionId/feedback/retry - 실패: 실패 상태가 아닌 피드백 (400)")
+    void retryFeedback_notFailed() throws Exception {
+        InterviewSession session = saveSession(3, 3, InterviewSessionStatus.FEEDBACK_PENDING, FeedbackStatus.PENDING);
+
+        mockMvc.perform(post("/api/interviews/{sessionId}/feedback/retry", session.getId())
+                        .header("Authorization", "Bearer " + validAccessToken))
+                .andDo(print())
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.error").value("VALIDATION_ERROR"))
+                .andDo(document("interview-retry-feedback-invalid-status",
+                        resource(RetryFeedbackDocs.invalidStatus())
+                ));
+    }
+
+    @Test
+    @DisplayName("POST /api/interviews/:sessionId/feedback/retry - 실패: 세션 없음 (404)")
+    void retryFeedback_sessionNotFound() throws Exception {
+        mockMvc.perform(post("/api/interviews/{sessionId}/feedback/retry", java.util.UUID.randomUUID())
+                        .header("Authorization", "Bearer " + validAccessToken))
+                .andDo(print())
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.error").value("RESOURCE_NOT_FOUND"))
+                .andDo(document("interview-retry-feedback-not-found",
+                        resource(RetryFeedbackDocs.notFound())
                 ));
     }
 

--- a/src/test/java/app/mockly/domain/interview/controller/docs/AbandonSessionDocs.java
+++ b/src/test/java/app/mockly/domain/interview/controller/docs/AbandonSessionDocs.java
@@ -1,0 +1,33 @@
+package app.mockly.domain.interview.controller.docs;
+
+import app.mockly.common.ApiResponseDocs;
+import com.epages.restdocs.apispec.HeaderDescriptorWithType;
+import com.epages.restdocs.apispec.ResourceSnippetParameters;
+
+import java.util.List;
+
+import static com.epages.restdocs.apispec.ResourceDocumentation.headerWithName;
+
+public class AbandonSessionDocs {
+
+    private static final List<HeaderDescriptorWithType> REQUEST_HEADERS = List.of(
+            headerWithName("Authorization").description("Bearer {accessToken}")
+    );
+
+    public static ResourceSnippetParameters success() {
+        return ResourceSnippetParameters.builder()
+                .tag("Interview")
+                .summary("면접 세션 포기")
+                .description("진행 중인 면접 세션을 포기 처리합니다. 이미 완료되거나 포기된 세션에는 사용할 수 없습니다.")
+                .requestHeaders(REQUEST_HEADERS)
+                .responseFields(ApiResponseDocs.noContentFields())
+                .build();
+    }
+
+    public static ResourceSnippetParameters alreadyCompleted() {
+        return ResourceSnippetParameters.builder()
+                .tag("Interview")
+                .responseFields(ApiResponseDocs.errorResponse("VALIDATION_ERROR"))
+                .build();
+    }
+}

--- a/src/test/java/app/mockly/domain/interview/controller/docs/FeedbackDocs.java
+++ b/src/test/java/app/mockly/domain/interview/controller/docs/FeedbackDocs.java
@@ -1,0 +1,48 @@
+package app.mockly.domain.interview.controller.docs;
+
+import app.mockly.common.ApiResponseDocs;
+import com.epages.restdocs.apispec.HeaderDescriptorWithType;
+import com.epages.restdocs.apispec.ResourceSnippetParameters;
+import com.epages.restdocs.apispec.SimpleType;
+import org.springframework.restdocs.payload.FieldDescriptor;
+import org.springframework.restdocs.payload.JsonFieldType;
+
+import java.util.List;
+
+import static com.epages.restdocs.apispec.ResourceDocumentation.headerWithName;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+
+public class FeedbackDocs {
+
+    private static final List<HeaderDescriptorWithType> REQUEST_HEADERS = List.of(
+            headerWithName("Authorization").description("Bearer {accessToken}")
+    );
+
+    private static final List<FieldDescriptor> RESPONSE_FIELDS = List.of(
+            fieldWithPath("overallScore").description("종합 점수 (1~100)").type(SimpleType.NUMBER),
+            fieldWithPath("expertFeedbacks").description("전문가별 평가 목록").type(JsonFieldType.ARRAY),
+            fieldWithPath("expertFeedbacks[].expertRole").description("전문가 역할").type(SimpleType.STRING),
+            fieldWithPath("expertFeedbacks[].score").description("전문가 평가 점수 (1~100)").type(SimpleType.NUMBER),
+            fieldWithPath("expertFeedbacks[].evaluation").description("전문가 평가 내용").type(SimpleType.STRING),
+            fieldWithPath("strengths").description("전반적인 강점").type(SimpleType.STRING),
+            fieldWithPath("improvements").description("전반적인 개선점").type(SimpleType.STRING),
+            fieldWithPath("detailedAnalysis").description("질문별 상세 분석 (PRO 플랜 전용)").type(SimpleType.STRING).optional()
+    );
+
+    public static ResourceSnippetParameters success() {
+        return ResourceSnippetParameters.builder()
+                .tag("Interview")
+                .summary("면접 피드백 조회")
+                .description("완료된 면접 세션의 AI 피드백을 조회합니다. 진행 중이거나 포기된 세션은 조회할 수 없습니다.")
+                .requestHeaders(REQUEST_HEADERS)
+                .responseFields(ApiResponseDocs.withDataFields(RESPONSE_FIELDS))
+                .build();
+    }
+
+    public static ResourceSnippetParameters notFound() {
+        return ResourceSnippetParameters.builder()
+                .tag("Interview")
+                .responseFields(ApiResponseDocs.errorResponse("RESOURCE_NOT_FOUND"))
+                .build();
+    }
+}

--- a/src/test/java/app/mockly/domain/interview/controller/docs/FeedbackDocs.java
+++ b/src/test/java/app/mockly/domain/interview/controller/docs/FeedbackDocs.java
@@ -19,21 +19,24 @@ public class FeedbackDocs {
     );
 
     private static final List<FieldDescriptor> RESPONSE_FIELDS = List.of(
-            fieldWithPath("overallScore").description("종합 점수 (1~100)").type(SimpleType.NUMBER),
-            fieldWithPath("expertFeedbacks").description("전문가별 평가 목록").type(JsonFieldType.ARRAY),
-            fieldWithPath("expertFeedbacks[].expertRole").description("전문가 역할").type(SimpleType.STRING),
-            fieldWithPath("expertFeedbacks[].score").description("전문가 평가 점수 (1~100)").type(SimpleType.NUMBER),
-            fieldWithPath("expertFeedbacks[].evaluation").description("전문가 평가 내용").type(SimpleType.STRING),
-            fieldWithPath("strengths").description("전반적인 강점").type(SimpleType.STRING),
-            fieldWithPath("improvements").description("전반적인 개선점").type(SimpleType.STRING),
-            fieldWithPath("detailedAnalysis").description("질문별 상세 분석 (PRO 플랜 전용)").type(SimpleType.STRING).optional()
+            fieldWithPath("feedbackStatus").description("피드백 상태 (PENDING | GENERATING | COMPLETED | FAILED)").type(SimpleType.STRING),
+            fieldWithPath("feedback").description("피드백 데이터 (COMPLETED 시)").type(JsonFieldType.OBJECT).optional(),
+            fieldWithPath("feedback.overallScore").description("종합 점수 (1~100)").type(SimpleType.NUMBER).optional(),
+            fieldWithPath("feedback.expertFeedbacks").description("전문가별 평가 목록").type(JsonFieldType.ARRAY).optional(),
+            fieldWithPath("feedback.expertFeedbacks[].expertRole").description("전문가 역할").type(SimpleType.STRING).optional(),
+            fieldWithPath("feedback.expertFeedbacks[].score").description("전문가 평가 점수 (1~100)").type(SimpleType.NUMBER).optional(),
+            fieldWithPath("feedback.expertFeedbacks[].evaluation").description("전문가 평가 내용").type(SimpleType.STRING).optional(),
+            fieldWithPath("feedback.strengths").description("전반적인 강점").type(SimpleType.STRING).optional(),
+            fieldWithPath("feedback.improvements").description("전반적인 개선점").type(SimpleType.STRING).optional(),
+            fieldWithPath("feedback.detailedAnalysis").description("질문별 상세 분석 (PRO 플랜 전용)").type(SimpleType.STRING).optional(),
+            fieldWithPath("message").description("오류 메시지 (FAILED 시)").type(SimpleType.STRING).optional()
     );
 
     public static ResourceSnippetParameters success() {
         return ResourceSnippetParameters.builder()
                 .tag("Interview")
                 .summary("면접 피드백 조회")
-                .description("완료된 면접 세션의 AI 피드백을 조회합니다. 진행 중이거나 포기된 세션은 조회할 수 없습니다.")
+                .description("면접 세션의 피드백 상태와 데이터를 조회합니다. COMPLETED이면 피드백 데이터 포함, PENDING/GENERATING이면 202, FAILED이면 오류 메시지 포함.")
                 .requestHeaders(REQUEST_HEADERS)
                 .responseFields(ApiResponseDocs.withDataFields(RESPONSE_FIELDS))
                 .build();

--- a/src/test/java/app/mockly/domain/interview/controller/docs/QuotaDocs.java
+++ b/src/test/java/app/mockly/domain/interview/controller/docs/QuotaDocs.java
@@ -1,0 +1,36 @@
+package app.mockly.domain.interview.controller.docs;
+
+import app.mockly.common.ApiResponseDocs;
+import com.epages.restdocs.apispec.HeaderDescriptorWithType;
+import com.epages.restdocs.apispec.ResourceSnippetParameters;
+import com.epages.restdocs.apispec.SimpleType;
+import org.springframework.restdocs.payload.FieldDescriptor;
+
+import java.util.List;
+
+import static com.epages.restdocs.apispec.ResourceDocumentation.headerWithName;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+
+public class QuotaDocs {
+
+    private static final List<HeaderDescriptorWithType> REQUEST_HEADERS = List.of(
+            headerWithName("Authorization").description("Bearer {accessToken}")
+    );
+
+    private static final List<FieldDescriptor> RESPONSE_FIELDS = List.of(
+            fieldWithPath("dailyLimit").description("플랜별 일일 허용 세션 수").type(SimpleType.NUMBER),
+            fieldWithPath("usedToday").description("오늘 사용한 세션 수").type(SimpleType.NUMBER),
+            fieldWithPath("remaining").description("오늘 남은 세션 수").type(SimpleType.NUMBER),
+            fieldWithPath("maxQuestionsPerSession").description("플랜별 세션당 최대 질문 수").type(SimpleType.NUMBER)
+    );
+
+    public static ResourceSnippetParameters success() {
+        return ResourceSnippetParameters.builder()
+                .tag("Interview")
+                .summary("면접 쿼터 조회")
+                .description("현재 플랜의 일일 면접 쿼터와 오늘 사용 현황을 조회합니다.")
+                .requestHeaders(REQUEST_HEADERS)
+                .responseFields(ApiResponseDocs.withDataFields(RESPONSE_FIELDS))
+                .build();
+    }
+}

--- a/src/test/java/app/mockly/domain/interview/controller/docs/RetryFeedbackDocs.java
+++ b/src/test/java/app/mockly/domain/interview/controller/docs/RetryFeedbackDocs.java
@@ -1,0 +1,62 @@
+package app.mockly.domain.interview.controller.docs;
+
+import app.mockly.common.ApiResponseDocs;
+import com.epages.restdocs.apispec.HeaderDescriptorWithType;
+import com.epages.restdocs.apispec.ResourceSnippetParameters;
+import com.epages.restdocs.apispec.SimpleType;
+import org.springframework.restdocs.payload.FieldDescriptor;
+import org.springframework.restdocs.payload.JsonFieldType;
+
+import java.util.List;
+
+import static com.epages.restdocs.apispec.ResourceDocumentation.headerWithName;
+import static com.epages.restdocs.apispec.ResourceDocumentation.parameterWithName;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+
+public class RetryFeedbackDocs {
+
+    private static final List<HeaderDescriptorWithType> REQUEST_HEADERS = List.of(
+            headerWithName("Authorization").description("Bearer {accessToken}")
+    );
+
+    private static final List<FieldDescriptor> RESPONSE_FIELDS = List.of(
+            fieldWithPath("feedbackStatus").description("피드백 상태 (PENDING)").type(SimpleType.STRING),
+            fieldWithPath("feedback").description("피드백 데이터 (COMPLETED 시)").type(JsonFieldType.OBJECT).optional(),
+            fieldWithPath("feedback.overallScore").description("종합 점수 (1~100)").type(SimpleType.NUMBER).optional(),
+            fieldWithPath("feedback.expertFeedbacks").description("전문가별 평가 목록").type(JsonFieldType.ARRAY).optional(),
+            fieldWithPath("feedback.expertFeedbacks[].expertRole").description("전문가 역할").type(SimpleType.STRING).optional(),
+            fieldWithPath("feedback.expertFeedbacks[].score").description("전문가 평가 점수 (1~100)").type(SimpleType.NUMBER).optional(),
+            fieldWithPath("feedback.expertFeedbacks[].evaluation").description("전문가 평가 내용").type(SimpleType.STRING).optional(),
+            fieldWithPath("feedback.strengths").description("전반적인 강점").type(SimpleType.STRING).optional(),
+            fieldWithPath("feedback.improvements").description("전반적인 개선점").type(SimpleType.STRING).optional(),
+            fieldWithPath("feedback.detailedAnalysis").description("질문별 상세 분석 (PRO 플랜 전용)").type(SimpleType.STRING).optional(),
+            fieldWithPath("message").description("오류 메시지 (FAILED 시)").type(SimpleType.STRING).optional()
+    );
+
+    public static ResourceSnippetParameters success() {
+        return ResourceSnippetParameters.builder()
+                .tag("Interview")
+                .summary("면접 피드백 재시도")
+                .description("실패한 면접 피드백 생성을 다시 요청합니다. FAILED 상태이면서 세션 상태가 FEEDBACK_PENDING인 경우에만 사용할 수 있습니다.")
+                .requestHeaders(REQUEST_HEADERS)
+                .pathParameters(parameterWithName("sessionId").description("면접 세션 ID"))
+                .responseFields(ApiResponseDocs.withDataFields(RESPONSE_FIELDS))
+                .build();
+    }
+
+    public static ResourceSnippetParameters invalidStatus() {
+        return ResourceSnippetParameters.builder()
+                .tag("Interview")
+                .pathParameters(parameterWithName("sessionId").description("면접 세션 ID"))
+                .responseFields(ApiResponseDocs.errorResponse("VALIDATION_ERROR"))
+                .build();
+    }
+
+    public static ResourceSnippetParameters notFound() {
+        return ResourceSnippetParameters.builder()
+                .tag("Interview")
+                .pathParameters(parameterWithName("sessionId").description("면접 세션 ID"))
+                .responseFields(ApiResponseDocs.errorResponse("RESOURCE_NOT_FOUND"))
+                .build();
+    }
+}

--- a/src/test/java/app/mockly/domain/interview/controller/docs/SubmitAnswerDocs.java
+++ b/src/test/java/app/mockly/domain/interview/controller/docs/SubmitAnswerDocs.java
@@ -5,7 +5,6 @@ import com.epages.restdocs.apispec.HeaderDescriptorWithType;
 import com.epages.restdocs.apispec.ResourceSnippetParameters;
 import com.epages.restdocs.apispec.SimpleType;
 import org.springframework.restdocs.payload.FieldDescriptor;
-import org.springframework.restdocs.payload.JsonFieldType;
 
 import java.util.List;
 
@@ -26,30 +25,21 @@ public class SubmitAnswerDocs {
             fieldWithPath("sessionId").description("면접 세션 ID").type(SimpleType.STRING),
             fieldWithPath("currentQuestionNumber").description("현재 질문 번호").type(SimpleType.NUMBER),
             fieldWithPath("totalQuestions").description("총 질문 개수").type(SimpleType.NUMBER),
-            fieldWithPath("isCompleted").description("면접 완료 여부").type(SimpleType.BOOLEAN),
-            fieldWithPath("feedback").description("피드백 (완료 시)").type(JsonFieldType.OBJECT).optional(),
-            fieldWithPath("feedback.overallScore").description("면접 종합 점수 (1~100)").type(SimpleType.NUMBER).optional(),
-            fieldWithPath("feedback.expertFeedbacks").description("전문가별 평가 목록").type(JsonFieldType.ARRAY).optional(),
-            fieldWithPath("feedback.expertFeedbacks[].expertRole").description("전문가 역할").type(SimpleType.STRING).optional(),
-            fieldWithPath("feedback.expertFeedbacks[].score").description("전문가 평가 점수 (1~100)").type(SimpleType.NUMBER).optional(),
-            fieldWithPath("feedback.expertFeedbacks[].evaluation").description("전문가 평가 내용").type(SimpleType.STRING).optional(),
-            fieldWithPath("feedback.strengths").description("전반적인 강점 요약").type(SimpleType.STRING).optional(),
-            fieldWithPath("feedback.improvements").description("전반적인 개선점 요약").type(SimpleType.STRING).optional(),
-            fieldWithPath("feedback.detailedAnalysis").description("질문별 상세 분석 (PRO 전용)").type(SimpleType.STRING).optional()
+            fieldWithPath("sessionStatus").description("세션 상태 (IN_PROGRESS | FEEDBACK_PENDING)").type(SimpleType.STRING)
     );
 
     public static ResourceSnippetParameters success() {
         return ResourceSnippetParameters.builder()
                 .tag("Interview")
                 .summary("답변 제출")
-                .description("면접 질문에 대한 답변을 제출합니다. 마지막 답변이면 피드백을 반환합니다. 다음 질문은 GET /{sessionId}/questions/stream SSE 엔드포인트로 수신합니다.")
+                .description("면접 질문에 대한 답변을 제출합니다. 마지막 답변이면 FEEDBACK_PENDING 상태를 반환하고 피드백은 비동기로 생성됩니다. 피드백 완료는 GET /{sessionId}/feedback/events SSE로 수신합니다.")
                 .requestHeaders(REQUEST_HEADERS)
                 .requestFields(REQUEST_FIELDS)
                 .responseFields(ApiResponseDocs.withDataFields(RESPONSE_FIELDS))
                 .build();
     }
 
-    public static ResourceSnippetParameters successCompleted() {
+    public static ResourceSnippetParameters feedbackPending() {
         return ResourceSnippetParameters.builder()
                 .tag("Interview")
                 .requestHeaders(REQUEST_HEADERS)

--- a/src/test/java/app/mockly/domain/interview/service/AiFeedbackLatencyTest.java
+++ b/src/test/java/app/mockly/domain/interview/service/AiFeedbackLatencyTest.java
@@ -1,0 +1,290 @@
+package app.mockly.domain.interview.service;
+
+import app.mockly.domain.auth.service.TokenBlacklistService;
+import app.mockly.domain.interview.dto.InterviewFeedbackResult;
+import app.mockly.domain.interview.entity.InterviewMessage;
+import app.mockly.domain.interview.entity.InterviewMessageRole;
+import app.mockly.domain.interview.entity.InterviewType;
+import app.mockly.domain.product.entity.PlanTier;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@ActiveProfiles("latency")
+@Tag("latency")
+class AiFeedbackLatencyTest {
+
+    @Autowired
+    private InterviewAiService interviewAiService;
+
+    @MockitoBean
+    private TokenBlacklistService tokenBlacklistService;
+
+    private static final int WARMUP = 10;
+    private static final int MEASUREMENT = 100;
+
+    @Test
+    void measureGenerateFeedbackLatency() {
+        List<List<InterviewMessage>> samples = createAllSamples();
+        List<Long> durations = new ArrayList<>();
+
+        for (int i = 0; i < WARMUP + MEASUREMENT; i++) {
+            List<InterviewMessage> history = samples.get(i % samples.size());
+            long start = System.nanoTime();
+            InterviewFeedbackResult result = interviewAiService.generateFeedback(
+                    history, InterviewType.TECHNICAL, PlanTier.PRO);
+            long elapsed = (System.nanoTime() - start) / 1_000_000;
+
+            if (i < WARMUP) {
+                System.out.printf("[warmup %2d] %,d ms%n", i + 1, elapsed);
+            } else {
+                durations.add(elapsed);
+                System.out.printf("[%3d/%d] %,d ms | score=%d experts=%d%n",
+                        i - WARMUP + 1, MEASUREMENT, elapsed,
+                        result.overallScore(), result.expertFeedbacks().size());
+            }
+        }
+
+        Collections.sort(durations);
+        double avg = durations.stream().mapToLong(Long::longValue).average().orElse(0);
+
+        System.out.println("\n========== generateFeedback() Latency Report ==========");
+        System.out.printf("  Samples : %d (warmup: %d)%n", MEASUREMENT, WARMUP);
+        System.out.printf("  Avg     : %,.0f ms%n", avg);
+        System.out.printf("  p50     : %,d ms%n", percentile(durations, 50));
+        System.out.printf("  p90     : %,d ms%n", percentile(durations, 90));
+        System.out.printf("  p95     : %,d ms%n", percentile(durations, 95));
+        System.out.printf("  p99     : %,d ms%n", percentile(durations, 99));
+        System.out.printf("  Max     : %,d ms%n", durations.get(durations.size() - 1));
+        System.out.println("=======================================================");
+
+        assertThat(durations).isNotEmpty();
+    }
+
+    private List<List<InterviewMessage>> createAllSamples() {
+        return List.of(
+                backendSample1(),
+                backendSample2(),
+                backendSample3(),
+                frontendSample1(),
+                frontendSample2(),
+                frontendSample3(),
+                plannerSample(),
+                marketerSample()
+        );
+    }
+
+    // ========== 백엔드 샘플 3개 ==========
+
+    private List<InterviewMessage> backendSample1() {
+        return List.of(
+                msg(InterviewMessageRole.INTERVIEWER, 1,
+                        "Spring Boot에서 의존성 주입(DI)이란 무엇이고, 어떤 방식으로 동작하는지 설명해주세요."),
+                msg(InterviewMessageRole.USER, 1,
+                        "의존성 주입은 객체가 필요로 하는 의존 객체를 직접 생성하지 않고 외부에서 주입받는 패턴입니다. " +
+                        "Spring에서는 IoC 컨테이너가 Bean을 관리하며, 생성자 주입, 세터 주입, 필드 주입 방식이 있습니다. " +
+                        "생성자 주입이 권장되는 이유는 불변성을 보장하고 순환 참조를 컴파일 타임에 발견할 수 있기 때문입니다."),
+                msg(InterviewMessageRole.INTERVIEWER, 2,
+                        "순환 참조가 발생하면 Spring은 어떻게 처리하나요? 실제로 경험해보신 적이 있으신가요?"),
+                msg(InterviewMessageRole.USER, 2,
+                        "생성자 주입에서 순환 참조가 발생하면 BeanCurrentlyInCreationException이 발생합니다. " +
+                        "프로젝트에서 Service A와 Service B가 서로 의존하는 상황이 있었는데, " +
+                        "공통 로직을 별도 서비스로 분리해서 해결했습니다. @Lazy를 쓸 수도 있지만 구조적으로 해결하는 것이 낫다고 판단했습니다."),
+                msg(InterviewMessageRole.INTERVIEWER, 3,
+                        "@Lazy와 구조적 분리 외에 순환 참조를 해결하는 다른 방법은 무엇이 있을까요?"),
+                msg(InterviewMessageRole.USER, 3,
+                        "이벤트 기반 처리로 의존성을 끊을 수 있습니다. ApplicationEventPublisher를 사용해서 " +
+                        "한쪽이 이벤트를 발행하고 다른 쪽이 리스너로 처리하면 직접 의존이 사라집니다. " +
+                        "또한 인터페이스를 도입해서 의존 방향을 역전시키는 DIP 적용도 방법입니다.")
+        );
+    }
+
+    private List<InterviewMessage> backendSample2() {
+        return List.of(
+                msg(InterviewMessageRole.INTERVIEWER, 1,
+                        "대규모 트래픽 환경에서 데이터베이스 조회 성능을 개선하기 위해 어떤 전략을 사용해보셨나요?"),
+                msg(InterviewMessageRole.USER, 1,
+                        "주문 조회 API에서 N+1 문제가 발생해서 응답 시간이 2초 이상 걸리는 상황이 있었습니다. " +
+                        "JPA의 fetch join으로 쿼리를 줄이고, 자주 조회되는 상품 정보는 Redis 캐시를 적용했습니다. " +
+                        "DB 인덱스도 복합 인덱스로 재설계해서 최종적으로 응답 시간을 200ms 이하로 줄였습니다. " +
+                        "추가로 읽기 전용 레플리카를 도입해서 조회 트래픽을 분산시켰습니다."),
+                msg(InterviewMessageRole.INTERVIEWER, 2,
+                        "Redis 캐시를 적용할 때 캐시 무효화(invalidation)는 어떻게 처리하셨나요?"),
+                msg(InterviewMessageRole.USER, 2,
+                        "상품 정보 수정 시 Cache-Aside 패턴으로 해당 키를 삭제하고 다음 조회 시 DB에서 다시 로드했습니다. " +
+                        "TTL은 5분으로 설정해서 최악의 경우에도 5분 뒤에는 최신 데이터가 반영됩니다. " +
+                        "캐시 스탬피드 문제를 방지하기 위해 분산 락을 적용할지 고민했지만, " +
+                        "해당 데이터의 갱신 빈도가 낮아서 TTL 기반으로 충분했습니다."),
+                msg(InterviewMessageRole.INTERVIEWER, 3,
+                        "캐시 스탬피드가 발생하면 구체적으로 어떤 문제가 생기고, 어떻게 대응하시겠어요?"),
+                msg(InterviewMessageRole.USER, 3,
+                        "TTL 만료 직후 다수의 요청이 동시에 DB를 조회해서 부하가 급증하는 현상입니다. " +
+                        "Redisson의 분산 락으로 하나의 요청만 DB를 조회하게 하거나, " +
+                        "TTL 만료 전에 미리 갱신하는 사전 로딩(pre-warming) 방식이 있습니다.")
+        );
+    }
+
+    private List<InterviewMessage> backendSample3() {
+        return List.of(
+                msg(InterviewMessageRole.INTERVIEWER, 1,
+                        "MSA 환경에서 서비스 간 트랜잭션 일관성을 어떻게 보장하셨나요?"),
+                msg(InterviewMessageRole.USER, 1,
+                        "잘 모르겠습니다. 아직 MSA를 직접 경험해보지는 못했습니다."),
+                msg(InterviewMessageRole.INTERVIEWER, 2,
+                        "그러면 모놀리식 환경에서 여러 서비스의 트랜잭션을 관리한 경험이 있으신가요?"),
+                msg(InterviewMessageRole.USER, 2,
+                        "@Transactional을 사용해서 주문과 결제를 하나의 트랜잭션으로 묶었습니다. " +
+                        "결제 실패 시 주문도 롤백되도록 했습니다."),
+                msg(InterviewMessageRole.INTERVIEWER, 3,
+                        "외부 결제 API 호출이 트랜잭션 안에 있으면 어떤 문제가 발생할 수 있을까요?"),
+                msg(InterviewMessageRole.USER, 3,
+                        "음... 외부 API가 느리면 트랜잭션이 오래 유지되는 문제가 있을 것 같습니다. " +
+                        "DB 커넥션을 오래 점유하게 되니까요. 근데 구체적으로 어떻게 해결하는지는 잘 모르겠습니다.")
+        );
+    }
+
+    // ========== 프론트엔드 샘플 3개 ==========
+
+    private List<InterviewMessage> frontendSample1() {
+        return List.of(
+                msg(InterviewMessageRole.INTERVIEWER, 1,
+                        "React에서 상태 관리를 할 때 useState와 useReducer를 어떤 기준으로 선택하시나요?"),
+                msg(InterviewMessageRole.USER, 1,
+                        "단순한 상태는 useState를 사용하고, 여러 하위 값이 연관되어 있거나 상태 전이 로직이 복잡한 경우 useReducer를 씁니다. " +
+                        "예를 들어 폼 데이터에서 필드 간 유효성 검증이 연쇄적으로 필요할 때 useReducer가 적합했습니다. " +
+                        "action 타입으로 상태 변화를 명시적으로 표현할 수 있어서 디버깅에도 유리합니다."),
+                msg(InterviewMessageRole.INTERVIEWER, 2,
+                        "전역 상태 관리 도구로는 무엇을 사용해보셨고, 선택 기준은 무엇이었나요?"),
+                msg(InterviewMessageRole.USER, 2,
+                        "Redux Toolkit과 Zustand를 모두 사용해봤습니다. 대규모 프로젝트에서는 RTK가 미들웨어와 DevTools 생태계가 잘 되어 있어서 선택했고, " +
+                        "소규모 프로젝트에서는 Zustand가 보일러플레이트가 적어서 생산성이 높았습니다. " +
+                        "서버 상태는 TanStack Query로 분리해서 클라이언트 상태와 서버 상태를 명확히 구분합니다."),
+                msg(InterviewMessageRole.INTERVIEWER, 3,
+                        "TanStack Query의 staleTime과 gcTime 설정은 어떤 기준으로 정하셨나요?"),
+                msg(InterviewMessageRole.USER, 3,
+                        "데이터 특성에 따라 다르게 설정합니다. 사용자 프로필처럼 변경이 드문 데이터는 staleTime을 5분으로, " +
+                        "실시간성이 중요한 알림 목록은 0으로 설정합니다. " +
+                        "gcTime은 기본 5분을 유지하되, 메모리 이슈가 관측되면 조정합니다.")
+        );
+    }
+
+    private List<InterviewMessage> frontendSample2() {
+        return List.of(
+                msg(InterviewMessageRole.INTERVIEWER, 1,
+                        "웹 성능 최적화를 위해 어떤 작업을 해보셨나요?"),
+                msg(InterviewMessageRole.USER, 1,
+                        "Lighthouse 점수가 40점대였던 프로젝트에서 이미지 최적화, 코드 스플리팅, 폰트 프리로드를 적용했습니다. " +
+                        "Next.js의 Image 컴포넌트로 WebP 변환과 lazy loading을 적용했고, " +
+                        "dynamic import로 초기 번들 크기를 60% 줄였습니다. " +
+                        "CLS 개선을 위해 이미지에 width/height를 명시하고, 스켈레톤 UI를 도입했습니다. " +
+                        "최종적으로 Lighthouse 점수를 92점까지 올렸습니다."),
+                msg(InterviewMessageRole.INTERVIEWER, 2,
+                        "코드 스플리팅을 적용할 때 청크 크기는 어떤 기준으로 나누셨나요?"),
+                msg(InterviewMessageRole.USER, 2,
+                        "라우트 단위로 기본 스플리팅하고, 큰 라이브러리(차트, 에디터)는 별도 청크로 분리했습니다. " +
+                        "Webpack Bundle Analyzer로 확인하면서 200KB 이상인 청크를 찾아 추가로 분리했습니다."),
+                msg(InterviewMessageRole.INTERVIEWER, 3,
+                        "SSR과 CSR 중 어떤 기준으로 렌더링 전략을 결정하시나요?"),
+                msg(InterviewMessageRole.USER, 3,
+                        "SEO가 필요한 페이지(상품 상세, 블로그)는 SSR 또는 SSG를 적용합니다. " +
+                        "대시보드처럼 인증이 필요하고 SEO가 불필요한 페이지는 CSR로 처리합니다. " +
+                        "ISR은 상품 목록처럼 데이터가 주기적으로 변하지만 실시간은 아닌 경우에 사용합니다.")
+        );
+    }
+
+    private List<InterviewMessage> frontendSample3() {
+        return List.of(
+                msg(InterviewMessageRole.INTERVIEWER, 1,
+                        "접근성(a11y)을 고려한 개발 경험이 있으신가요?"),
+                msg(InterviewMessageRole.USER, 1,
+                        "네, WAI-ARIA 속성을 적용하고 키보드 네비게이션을 지원하도록 개발했습니다."),
+                msg(InterviewMessageRole.INTERVIEWER, 2,
+                        "구체적으로 어떤 컴포넌트에서 어떤 ARIA 속성을 사용하셨나요?"),
+                msg(InterviewMessageRole.USER, 2,
+                        "드롭다운 메뉴에서 aria-expanded, aria-haspopup을 사용했고, " +
+                        "모달에는 aria-modal, role='dialog'를 적용했습니다. " +
+                        "탭 컴포넌트에서는 role='tablist', 'tab', 'tabpanel'을 사용해서 " +
+                        "스크린 리더가 탭 구조를 인식하도록 했습니다."),
+                msg(InterviewMessageRole.INTERVIEWER, 3,
+                        "접근성 테스트는 어떤 방식으로 진행하셨나요?"),
+                msg(InterviewMessageRole.USER, 3,
+                        "axe-core 기반의 jest-axe로 자동화 테스트를 작성하고, " +
+                        "실제 VoiceOver와 NVDA로 수동 테스트를 병행했습니다. " +
+                        "Lighthouse 접근성 점수도 CI에서 90점 이상을 유지하도록 설정했습니다.")
+        );
+    }
+
+    // ========== 기획자 / PM / 마케터 샘플 ==========
+
+    private List<InterviewMessage> plannerSample() {
+        return List.of(
+                msg(InterviewMessageRole.INTERVIEWER, 1,
+                        "신규 기능을 기획할 때 우선순위를 어떤 기준으로 정하시나요?"),
+                msg(InterviewMessageRole.USER, 1,
+                        "RICE 프레임워크를 주로 사용합니다. Reach, Impact, Confidence, Effort를 점수화해서 비교합니다. " +
+                        "하지만 RICE만으로는 전략적 방향성을 놓칠 수 있어서, OKR과 연결해서 상위 목표에 기여하는지를 먼저 판단합니다. " +
+                        "데이터가 부족한 초기 기능은 유저 인터뷰 결과를 Confidence 산정에 반영합니다."),
+                msg(InterviewMessageRole.INTERVIEWER, 2,
+                        "개발팀과 일정 협의 시 의견이 충돌하면 어떻게 조율하시나요?"),
+                msg(InterviewMessageRole.USER, 2,
+                        "기술적 제약을 충분히 이해하려고 노력합니다. 개발 리드와 1:1로 먼저 대화해서 " +
+                        "어떤 부분이 기술적으로 어렵고 왜 그런지 파악합니다. " +
+                        "그 후 MVP 범위를 조정하거나, 페이즈를 나눠서 핵심 기능만 먼저 배포하는 방식으로 타협점을 찾습니다. " +
+                        "중요한 건 일방적으로 밀어붙이지 않고 상호 합의된 마일스톤을 만드는 것입니다."),
+                msg(InterviewMessageRole.INTERVIEWER, 3,
+                        "기획한 기능이 출시 후 기대한 성과를 내지 못했던 경험이 있나요? 어떻게 대응하셨나요?"),
+                msg(InterviewMessageRole.USER, 3,
+                        "소셜 공유 기능을 추가했는데 사용률이 2%도 안 됐습니다. " +
+                        "유저 행동 데이터를 분석해보니 공유 버튼 위치가 너무 깊었고, 공유할 동기도 부족했습니다. " +
+                        "A/B 테스트로 버튼 위치를 변경하고 공유 시 포인트 리워드를 추가한 결과 12%까지 올릴 수 있었습니다.")
+        );
+    }
+
+    private List<InterviewMessage> marketerSample() {
+        return List.of(
+                msg(InterviewMessageRole.INTERVIEWER, 1,
+                        "디지털 마케팅 캠페인을 설계할 때 어떤 프로세스를 따르시나요?"),
+                msg(InterviewMessageRole.USER, 1,
+                        "먼저 캠페인 목표를 명확히 정의합니다. 인지도인지 전환인지에 따라 채널과 메시지가 완전히 달라지기 때문입니다. " +
+                        "타겟 오디언스를 세그먼트하고, 채널별 크리에이티브를 준비한 뒤 A/B 테스트를 설계합니다. " +
+                        "런칭 후에는 일별로 핵심 지표(CTR, CPA, ROAS)를 모니터링하며 실시간으로 예산을 재배분합니다."),
+                msg(InterviewMessageRole.INTERVIEWER, 2,
+                        "퍼포먼스 마케팅에서 ROAS가 목표 이하일 때 어떻게 개선하셨나요?"),
+                msg(InterviewMessageRole.USER, 2,
+                        "Facebook Ads에서 ROAS 1.5 목표 대비 0.8이 나왔던 경험이 있습니다. " +
+                        "퍼널별로 분석해보니 랜딩 페이지 이탈률이 70%로 높았습니다. " +
+                        "크리에이티브와 랜딩 메시지의 불일치가 원인이었고, " +
+                        "랜딩 페이지를 광고 소재와 일치시키고 CTA를 강화한 결과 ROAS 2.1까지 개선했습니다."),
+                msg(InterviewMessageRole.INTERVIEWER, 3,
+                        "마케팅 성과를 비마케팅 팀(경영진, 개발팀)에 어떻게 커뮤니케이션하시나요?"),
+                msg(InterviewMessageRole.USER, 3,
+                        "경영진에게는 비즈니스 임팩트 중심으로 보고합니다. CTR이나 CPC 같은 채널 지표보다 " +
+                        "매출 기여, CAC, LTV 같은 비즈니스 지표를 앞에 놓습니다. " +
+                        "개발팀에게는 UTM 파라미터 설계나 이벤트 트래킹 요구사항을 구체적인 스펙으로 전달합니다. " +
+                        "주간 리포트는 대시보드 링크와 핵심 인사이트 3줄로 요약해서 공유합니다.")
+        );
+    }
+
+    private long percentile(List<Long> sorted, double percentile) {
+        int index = (int) Math.ceil(percentile / 100.0 * sorted.size()) - 1;
+        return sorted.get(Math.max(0, Math.min(index, sorted.size() - 1)));
+    }
+
+    private InterviewMessage msg(InterviewMessageRole role, int questionNumber, String content) {
+        return InterviewMessage.builder()
+                .role(role)
+                .content(content)
+                .questionNumber(questionNumber)
+                .build();
+    }
+}

--- a/src/test/java/app/mockly/domain/interview/service/FeedbackGenerationHandlerTest.java
+++ b/src/test/java/app/mockly/domain/interview/service/FeedbackGenerationHandlerTest.java
@@ -154,4 +154,26 @@ class FeedbackGenerationHandlerTest {
         verify(feedbackSseManager, never()).send(eq(sessionId), eq(FeedbackStatus.FAILED), anyString());
         verify(feedbackSseManager, never()).complete(sessionId);
     }
+
+    @Test
+    @DisplayName("AI 실패 처리 중 이미 완료된 세션이면 실패 메시지 없이 완료 상태만 전송한다")
+    void handle_aiFailureButAlreadyCompleted_sendsCompletedWithoutFailureMessage() {
+        UUID sessionId = UUID.randomUUID();
+        UUID userId = UUID.randomUUID();
+        FeedbackGenerationContext generationContext = new FeedbackGenerationContext(
+                List.of(), InterviewType.TECHNICAL, PlanTier.FREE);
+        FeedbackContext feedbackContext = new FeedbackContext(generationContext, FeedbackStatus.GENERATING);
+
+        given(txHelper.markGeneratingAndLoadContext(sessionId, userId)).willReturn(Optional.of(feedbackContext));
+        given(interviewAiService.generateFeedback(List.of(), InterviewType.TECHNICAL, PlanTier.FREE))
+                .willThrow(new RuntimeException("ai error"));
+        given(txHelper.markFailed(eq(sessionId), anyString())).willReturn(FeedbackStatus.COMPLETED);
+
+        handler.handle(new FeedbackRequestedEvent(sessionId, userId));
+
+        verify(feedbackSseManager).send(sessionId, FeedbackStatus.COMPLETED);
+        verify(feedbackSseManager, never()).send(eq(sessionId), eq(FeedbackStatus.COMPLETED), anyString());
+        verify(feedbackSseManager, never()).send(eq(sessionId), eq(FeedbackStatus.FAILED), anyString());
+        verify(feedbackSseManager).complete(sessionId);
+    }
 }

--- a/src/test/java/app/mockly/domain/interview/service/FeedbackGenerationHandlerTest.java
+++ b/src/test/java/app/mockly/domain/interview/service/FeedbackGenerationHandlerTest.java
@@ -20,6 +20,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
@@ -175,5 +176,57 @@ class FeedbackGenerationHandlerTest {
         verify(feedbackSseManager, never()).send(eq(sessionId), eq(FeedbackStatus.COMPLETED), anyString());
         verify(feedbackSseManager, never()).send(eq(sessionId), eq(FeedbackStatus.FAILED), anyString());
         verify(feedbackSseManager).complete(sessionId);
+    }
+
+    @Test
+    @DisplayName("retry backoff 중 인터럽트가 발생하면 실패 마킹과 SSE 없이 중단한다")
+    void handle_interruptedDuringRetryBackoff_doesNotMarkFailed() {
+        UUID sessionId = UUID.randomUUID();
+        UUID userId = UUID.randomUUID();
+        FeedbackGenerationContext generationContext = new FeedbackGenerationContext(
+                List.of(), InterviewType.TECHNICAL, PlanTier.FREE);
+        FeedbackContext feedbackContext = new FeedbackContext(generationContext, FeedbackStatus.GENERATING);
+
+        given(txHelper.markGeneratingAndLoadContext(sessionId, userId)).willReturn(Optional.of(feedbackContext));
+        given(interviewAiService.generateFeedback(List.of(), InterviewType.TECHNICAL, PlanTier.FREE))
+                .willThrow(new RuntimeException("temporary ai error"));
+
+        try {
+            Thread.currentThread().interrupt();
+
+            handler.handle(new FeedbackRequestedEvent(sessionId, userId));
+
+            assertThat(Thread.currentThread().isInterrupted()).isTrue();
+            verify(txHelper, never()).markFailed(any(), anyString());
+            verify(feedbackSseManager, never()).send(eq(sessionId), eq(FeedbackStatus.FAILED), anyString());
+            verify(feedbackSseManager, never()).complete(sessionId);
+        } finally {
+            Thread.interrupted();
+        }
+    }
+
+    @Test
+    @DisplayName("AI 예외 cause chain에 인터럽트가 있으면 실패 마킹과 SSE 없이 중단한다")
+    void handle_interruptedCause_doesNotMarkFailed() {
+        UUID sessionId = UUID.randomUUID();
+        UUID userId = UUID.randomUUID();
+        FeedbackGenerationContext generationContext = new FeedbackGenerationContext(
+                List.of(), InterviewType.TECHNICAL, PlanTier.FREE);
+        FeedbackContext feedbackContext = new FeedbackContext(generationContext, FeedbackStatus.GENERATING);
+
+        given(txHelper.markGeneratingAndLoadContext(sessionId, userId)).willReturn(Optional.of(feedbackContext));
+        given(interviewAiService.generateFeedback(List.of(), InterviewType.TECHNICAL, PlanTier.FREE))
+                .willThrow(new RuntimeException("wrapped", new RuntimeException(new InterruptedException())));
+
+        try {
+            handler.handle(new FeedbackRequestedEvent(sessionId, userId));
+
+            assertThat(Thread.currentThread().isInterrupted()).isTrue();
+            verify(txHelper, never()).markFailed(any(), anyString());
+            verify(feedbackSseManager, never()).send(eq(sessionId), eq(FeedbackStatus.FAILED), anyString());
+            verify(feedbackSseManager, never()).complete(sessionId);
+        } finally {
+            Thread.interrupted();
+        }
     }
 }

--- a/src/test/java/app/mockly/domain/interview/service/FeedbackGenerationHandlerTest.java
+++ b/src/test/java/app/mockly/domain/interview/service/FeedbackGenerationHandlerTest.java
@@ -1,0 +1,157 @@
+package app.mockly.domain.interview.service;
+
+import app.mockly.domain.interview.dto.FeedbackContext;
+import app.mockly.domain.interview.dto.FeedbackGenerationContext;
+import app.mockly.domain.interview.dto.InterviewFeedbackResult;
+import app.mockly.domain.interview.entity.FeedbackStatus;
+import app.mockly.domain.interview.entity.InterviewType;
+import app.mockly.domain.interview.event.FeedbackRequestedEvent;
+import app.mockly.domain.product.entity.PlanTier;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class FeedbackGenerationHandlerTest {
+
+    @Mock
+    private FeedbackTransactionHelper txHelper;
+
+    @Mock
+    private InterviewAiService interviewAiService;
+
+    @Mock
+    private FeedbackSseManager feedbackSseManager;
+
+    @Spy
+    private ObjectMapper objectMapper = new ObjectMapper();
+
+    @InjectMocks
+    private FeedbackGenerationHandler handler;
+
+    @Test
+    @DisplayName("중복 이벤트는 AI 호출과 실패 마킹 없이 skip한다")
+    void handle_duplicateEvent_skipsWithoutFailure() {
+        UUID sessionId = UUID.randomUUID();
+        UUID userId = UUID.randomUUID();
+
+        given(txHelper.markGeneratingAndLoadContext(sessionId, userId)).willReturn(Optional.empty());
+
+        handler.handle(new FeedbackRequestedEvent(sessionId, userId));
+
+        verify(interviewAiService, never()).generateFeedback(any(), any(), any());
+        verify(txHelper, never()).saveFeedbackAndComplete(any(), any(), anyString());
+        verify(txHelper, never()).markFailed(any(), anyString());
+        verify(feedbackSseManager, never()).send(eq(sessionId), eq(FeedbackStatus.FAILED), anyString());
+    }
+
+    @Test
+    @DisplayName("같은 이벤트가 두 번 들어오면 작업권을 얻은 첫 요청만 AI를 호출한다")
+    void handle_sameEventTwice_callsAiOnce() {
+        UUID sessionId = UUID.randomUUID();
+        UUID userId = UUID.randomUUID();
+        FeedbackGenerationContext generationContext = new FeedbackGenerationContext(
+                List.of(), InterviewType.TECHNICAL, PlanTier.FREE);
+        FeedbackContext feedbackContext = new FeedbackContext(generationContext, FeedbackStatus.GENERATING);
+        InterviewFeedbackResult result = new InterviewFeedbackResult(
+                80,
+                List.of(new InterviewFeedbackResult.ExpertFeedback("기술 면접관", 80, "좋습니다.")),
+                "강점",
+                "개선점",
+                null
+        );
+
+        given(txHelper.markGeneratingAndLoadContext(sessionId, userId))
+                .willReturn(Optional.of(feedbackContext))
+                .willReturn(Optional.empty());
+        given(interviewAiService.generateFeedback(List.of(), InterviewType.TECHNICAL, PlanTier.FREE))
+                .willReturn(result);
+        given(txHelper.saveFeedbackAndComplete(eq(sessionId), eq(result), anyString()))
+                .willReturn(Optional.of(FeedbackStatus.COMPLETED));
+
+        FeedbackRequestedEvent event = new FeedbackRequestedEvent(sessionId, userId);
+        handler.handle(event);
+        handler.handle(event);
+
+        verify(interviewAiService, times(1)).generateFeedback(List.of(), InterviewType.TECHNICAL, PlanTier.FREE);
+        verify(txHelper, times(1)).saveFeedbackAndComplete(eq(sessionId), eq(result), anyString());
+        verify(txHelper, never()).markFailed(any(), anyString());
+    }
+
+    @Test
+    @DisplayName("늦은 완료 worker는 완료/실패 SSE 없이 skip한다")
+    void handle_lateCompletionWorker_skipsWithoutSse() {
+        UUID sessionId = UUID.randomUUID();
+        UUID userId = UUID.randomUUID();
+        FeedbackGenerationContext generationContext = new FeedbackGenerationContext(
+                List.of(), InterviewType.TECHNICAL, PlanTier.FREE);
+        FeedbackContext feedbackContext = new FeedbackContext(generationContext, FeedbackStatus.GENERATING);
+        InterviewFeedbackResult result = new InterviewFeedbackResult(
+                80,
+                List.of(new InterviewFeedbackResult.ExpertFeedback("기술 면접관", 80, "좋습니다.")),
+                "강점",
+                "개선점",
+                null
+        );
+
+        given(txHelper.markGeneratingAndLoadContext(sessionId, userId)).willReturn(Optional.of(feedbackContext));
+        given(interviewAiService.generateFeedback(List.of(), InterviewType.TECHNICAL, PlanTier.FREE))
+                .willReturn(result);
+        given(txHelper.saveFeedbackAndComplete(eq(sessionId), eq(result), anyString()))
+                .willReturn(Optional.empty());
+
+        handler.handle(new FeedbackRequestedEvent(sessionId, userId));
+
+        verify(txHelper, never()).markFailed(any(), anyString());
+        verify(feedbackSseManager, never()).send(eq(sessionId), eq(FeedbackStatus.COMPLETED));
+        verify(feedbackSseManager, never()).send(eq(sessionId), eq(FeedbackStatus.FAILED), anyString());
+        verify(feedbackSseManager, never()).complete(sessionId);
+    }
+
+    @Test
+    @DisplayName("피드백 저장 실패는 FAILED 마킹이나 SSE 없이 stale recovery에 맡긴다")
+    void handle_feedbackSaveFailure_doesNotMarkFailed() {
+        UUID sessionId = UUID.randomUUID();
+        UUID userId = UUID.randomUUID();
+        FeedbackGenerationContext generationContext = new FeedbackGenerationContext(
+                List.of(), InterviewType.TECHNICAL, PlanTier.FREE);
+        FeedbackContext feedbackContext = new FeedbackContext(generationContext, FeedbackStatus.GENERATING);
+        InterviewFeedbackResult result = new InterviewFeedbackResult(
+                80,
+                List.of(new InterviewFeedbackResult.ExpertFeedback("기술 면접관", 80, "좋습니다.")),
+                "강점",
+                "개선점",
+                null
+        );
+
+        given(txHelper.markGeneratingAndLoadContext(sessionId, userId)).willReturn(Optional.of(feedbackContext));
+        given(interviewAiService.generateFeedback(List.of(), InterviewType.TECHNICAL, PlanTier.FREE))
+                .willReturn(result);
+        given(txHelper.saveFeedbackAndComplete(eq(sessionId), eq(result), anyString()))
+                .willThrow(new FeedbackTransactionHelper.FeedbackCompletionException("저장 실패", new RuntimeException()));
+
+        handler.handle(new FeedbackRequestedEvent(sessionId, userId));
+
+        verify(txHelper, never()).markFailed(any(), anyString());
+        verify(feedbackSseManager, never()).send(eq(sessionId), eq(FeedbackStatus.COMPLETED));
+        verify(feedbackSseManager, never()).send(eq(sessionId), eq(FeedbackStatus.FAILED), anyString());
+        verify(feedbackSseManager, never()).complete(sessionId);
+    }
+}

--- a/src/test/java/app/mockly/domain/interview/service/FeedbackTransactionHelperTest.java
+++ b/src/test/java/app/mockly/domain/interview/service/FeedbackTransactionHelperTest.java
@@ -1,0 +1,199 @@
+package app.mockly.domain.interview.service;
+
+import app.mockly.domain.interview.dto.FeedbackContext;
+import app.mockly.domain.interview.entity.ExperienceLevel;
+import app.mockly.domain.interview.entity.FeedbackStatus;
+import app.mockly.domain.interview.entity.InterviewFeedback;
+import app.mockly.domain.interview.entity.InterviewSession;
+import app.mockly.domain.interview.entity.InterviewSessionStatus;
+import app.mockly.domain.interview.entity.InterviewType;
+import app.mockly.domain.interview.dto.InterviewFeedbackResult;
+import app.mockly.domain.interview.repository.InterviewFeedbackRepository;
+import app.mockly.domain.interview.repository.InterviewMessageRepository;
+import app.mockly.domain.interview.repository.InterviewSessionRepository;
+import app.mockly.domain.product.repository.SubscriptionRepository;
+import app.mockly.global.common.ApiStatusCode;
+import app.mockly.global.exception.BusinessException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+@ExtendWith(MockitoExtension.class)
+class FeedbackTransactionHelperTest {
+
+    @Mock
+    private InterviewSessionRepository interviewSessionRepository;
+
+    @Mock
+    private InterviewMessageRepository interviewMessageRepository;
+
+    @Mock
+    private InterviewFeedbackRepository interviewFeedbackRepository;
+
+    @Mock
+    private SubscriptionRepository subscriptionRepository;
+
+    @InjectMocks
+    private FeedbackTransactionHelper txHelper;
+
+    @Test
+    @DisplayName("PENDING 세션이면 GENERATING 전이 후 AI context를 반환한다")
+    void markGeneratingAndLoadContext_pending_returnsContext() {
+        UUID sessionId = UUID.randomUUID();
+        UUID userId = UUID.randomUUID();
+        InterviewSession session = InterviewSession.builder()
+                .id(sessionId)
+                .position("백엔드 개발자")
+                .experienceLevel(ExperienceLevel.JUNIOR)
+                .interviewType(InterviewType.TECHNICAL)
+                .totalQuestions(3)
+                .selfIntroduction("자기소개")
+                .currentQuestionNumber(3)
+                .status(InterviewSessionStatus.FEEDBACK_PENDING)
+                .feedbackStatus(FeedbackStatus.GENERATING)
+                .build();
+
+        given(interviewSessionRepository.markFeedbackGeneratingIfPending(
+                eq(sessionId), eq(FeedbackStatus.PENDING), eq(FeedbackStatus.GENERATING), any(Instant.class)))
+                .willReturn(1);
+        given(interviewSessionRepository.findById(sessionId)).willReturn(Optional.of(session));
+        given(subscriptionRepository.findByUserIdAndStatus(eq(userId), any())).willReturn(Optional.empty());
+        given(interviewMessageRepository.findBySessionIdOrderByIdAsc(sessionId)).willReturn(List.of());
+
+        Optional<FeedbackContext> result = txHelper.markGeneratingAndLoadContext(sessionId, userId);
+
+        assertThat(result).isPresent();
+        assertThat(result.get().feedbackStatus()).isEqualTo(FeedbackStatus.GENERATING);
+        assertThat(result.get().context().interviewType()).isEqualTo(InterviewType.TECHNICAL);
+    }
+
+    @Test
+    @DisplayName("PENDING이 아니면 중복 작업으로 보고 context 로드를 생략한다")
+    void markGeneratingAndLoadContext_notPending_returnsEmpty() {
+        UUID sessionId = UUID.randomUUID();
+        UUID userId = UUID.randomUUID();
+
+        given(interviewSessionRepository.markFeedbackGeneratingIfPending(
+                eq(sessionId), eq(FeedbackStatus.PENDING), eq(FeedbackStatus.GENERATING), any(Instant.class)))
+                .willReturn(0);
+        given(interviewSessionRepository.existsById(sessionId)).willReturn(true);
+
+        Optional<FeedbackContext> result = txHelper.markGeneratingAndLoadContext(sessionId, userId);
+
+        assertThat(result).isEmpty();
+        verify(interviewSessionRepository, never()).findById(any());
+        verify(interviewMessageRepository, never()).findBySessionIdOrderByIdAsc(any());
+        verify(subscriptionRepository, never()).findByUserIdAndStatus(any(), any());
+    }
+
+    @Test
+    @DisplayName("세션이 없으면 기존처럼 RESOURCE_NOT_FOUND 예외를 던진다")
+    void markGeneratingAndLoadContext_missingSession_throwsNotFound() {
+        UUID sessionId = UUID.randomUUID();
+        UUID userId = UUID.randomUUID();
+
+        given(interviewSessionRepository.markFeedbackGeneratingIfPending(
+                eq(sessionId), eq(FeedbackStatus.PENDING), eq(FeedbackStatus.GENERATING), any(Instant.class)))
+                .willReturn(0);
+        given(interviewSessionRepository.existsById(sessionId)).willReturn(false);
+
+        assertThatThrownBy(() -> txHelper.markGeneratingAndLoadContext(sessionId, userId))
+                .isInstanceOf(BusinessException.class)
+                .extracting("statusCode")
+                .isEqualTo(ApiStatusCode.RESOURCE_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("GENERATING 세션이면 완료 전이 후 피드백을 저장한다")
+    void saveFeedbackAndComplete_generating_savesFeedback() {
+        UUID sessionId = UUID.randomUUID();
+        InterviewFeedbackResult result = feedbackResult();
+
+        given(interviewSessionRepository.completeFeedbackIfGenerating(
+                eq(sessionId),
+                eq(FeedbackStatus.GENERATING),
+                eq(FeedbackStatus.COMPLETED),
+                eq(InterviewSessionStatus.COMPLETED),
+                any(Instant.class),
+                any(Instant.class)))
+                .willReturn(1);
+        given(interviewSessionRepository.getReferenceById(sessionId)).willReturn(InterviewSession.builder()
+                .id(sessionId)
+                .build());
+
+        Optional<FeedbackStatus> status = txHelper.saveFeedbackAndComplete(sessionId, result, "[]");
+
+        assertThat(status).contains(FeedbackStatus.COMPLETED);
+        verify(interviewFeedbackRepository).saveAndFlush(any(InterviewFeedback.class));
+    }
+
+    @Test
+    @DisplayName("이미 완료 처리 중인 늦은 worker는 피드백을 저장하지 않는다")
+    void saveFeedbackAndComplete_lateWorker_returnsEmpty() {
+        UUID sessionId = UUID.randomUUID();
+
+        given(interviewSessionRepository.completeFeedbackIfGenerating(
+                eq(sessionId),
+                eq(FeedbackStatus.GENERATING),
+                eq(FeedbackStatus.COMPLETED),
+                eq(InterviewSessionStatus.COMPLETED),
+                any(Instant.class),
+                any(Instant.class)))
+                .willReturn(0);
+
+        Optional<FeedbackStatus> status = txHelper.saveFeedbackAndComplete(sessionId, feedbackResult(), "[]");
+
+        assertThat(status).isEmpty();
+        verify(interviewSessionRepository, never()).getReferenceById(any());
+        verifyNoInteractions(interviewFeedbackRepository);
+    }
+
+    @Test
+    @DisplayName("완료 claim 후 피드백 저장 실패는 완료 저장 예외로 전파한다")
+    void saveFeedbackAndComplete_saveFailure_throwsCompletionException() {
+        UUID sessionId = UUID.randomUUID();
+
+        given(interviewSessionRepository.completeFeedbackIfGenerating(
+                eq(sessionId),
+                eq(FeedbackStatus.GENERATING),
+                eq(FeedbackStatus.COMPLETED),
+                eq(InterviewSessionStatus.COMPLETED),
+                any(Instant.class),
+                any(Instant.class)))
+                .willReturn(1);
+        given(interviewSessionRepository.getReferenceById(sessionId)).willReturn(InterviewSession.builder()
+                .id(sessionId)
+                .build());
+        given(interviewFeedbackRepository.saveAndFlush(any(InterviewFeedback.class))).willThrow(new RuntimeException("db error"));
+
+        assertThatThrownBy(() -> txHelper.saveFeedbackAndComplete(sessionId, feedbackResult(), "[]"))
+                .isInstanceOf(FeedbackTransactionHelper.FeedbackCompletionException.class);
+    }
+
+    private InterviewFeedbackResult feedbackResult() {
+        return new InterviewFeedbackResult(
+                80,
+                List.of(new InterviewFeedbackResult.ExpertFeedback("기술 면접관", 80, "좋습니다.")),
+                "강점",
+                "개선점",
+                null
+        );
+    }
+}

--- a/src/test/java/app/mockly/domain/interview/service/StaleFeedbackRecoveryJobTest.java
+++ b/src/test/java/app/mockly/domain/interview/service/StaleFeedbackRecoveryJobTest.java
@@ -1,0 +1,60 @@
+package app.mockly.domain.interview.service;
+
+import app.mockly.domain.interview.entity.FeedbackStatus;
+import app.mockly.domain.interview.repository.InterviewSessionRepository;
+import app.mockly.global.config.InterviewFeedbackProperties;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
+
+import java.time.Instant;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class StaleFeedbackRecoveryJobTest {
+
+    @Mock
+    private InterviewSessionRepository interviewSessionRepository;
+
+    @Mock
+    private ApplicationEventPublisher eventPublisher;
+
+    @Test
+    @DisplayName("설정된 stale threshold 기준으로 stuck 세션을 조회한다")
+    void recoverStaleFeedbacks_usesConfiguredThreshold() {
+        InterviewFeedbackProperties properties = new InterviewFeedbackProperties();
+        properties.setStaleThresholdMinutes(10);
+        StaleFeedbackRecoveryJob job = new StaleFeedbackRecoveryJob(
+                interviewSessionRepository, eventPublisher, properties);
+        ArgumentCaptor<Instant> thresholdCaptor = ArgumentCaptor.forClass(Instant.class);
+        Instant before = Instant.now();
+        given(interviewSessionRepository.findByFeedbackStatusInAndUpdatedAtBefore(
+                eq(List.of(FeedbackStatus.PENDING, FeedbackStatus.GENERATING)), thresholdCaptor.capture()))
+                .willReturn(List.of());
+
+        job.recoverStaleFeedbacks();
+
+        Instant after = Instant.now();
+        assertThat(thresholdCaptor.getValue())
+                .isBetween(before.minusSeconds(10 * 60L), after.minusSeconds(10 * 60L));
+        verify(interviewSessionRepository).findByFeedbackStatusInAndUpdatedAtBefore(
+                eq(List.of(FeedbackStatus.PENDING, FeedbackStatus.GENERATING)), eq(thresholdCaptor.getValue()));
+    }
+
+    @Test
+    @DisplayName("stale threshold 기본값은 기존과 동일하게 6분이다")
+    void interviewFeedbackProperties_defaultThresholdIsSixMinutes() {
+        InterviewFeedbackProperties properties = new InterviewFeedbackProperties();
+
+        assertThat(properties.getStaleThresholdMinutes()).isEqualTo(6);
+    }
+}

--- a/src/test/resources/application-latency.yaml
+++ b/src/test/resources/application-latency.yaml
@@ -1,0 +1,8 @@
+spring.ai:
+  openai:
+    api-key: ${OPENAI_API_KEY}
+
+interview:
+  ai:
+    keyword-extraction-model: gpt-4o-mini
+    keyword-extraction-temperature: 0.7


### PR DESCRIPTION
## 개요

AI 면접의 마지막 답변 제출 이후 피드백 생성을 비동기로 처리하도록 개선했습니다.
답변 제출 API는 피드백 생성을 기다리지 않고 `FEEDBACK_PENDING`을 반환하고, 클라이언트는 SSE 또는 피드백 조회 API로 상태를 확인합니다.
비동기 worker의 중복 실행, stale recovery, SSE 상태 전달 경합을 보강해 운영 중 상태 불일치 가능성을 줄였습니다.

## 주요 변경사항

### ⚡ 비동기 피드백 생성
- 마지막 답변 제출 시 세션을 `FEEDBACK_PENDING`으로 전환하고 `FeedbackRequestedEvent` 발행
- `@TransactionalEventListener(AFTER_COMMIT)` + `@Async` 기반으로 커밋 이후 피드백 생성 worker 실행
- AI 호출은 트랜잭션 밖에서 수행하고, 상태 전이와 저장만 짧은 트랜잭션으로 분리

### 📡 피드백 상태 SSE
- `GET /api/interviews/:sessionId/feedback/events` 추가
- SSE 연결 전 세션 소유권과 피드백 상태를 먼저 검증하도록 수정
- 이미 완료/실패된 피드백은 DB 상태 조회 fallback으로 즉시 상태 이벤트 전송
- 완료된 세션에 실패 SSE 메시지가 섞이지 않도록 실패 처리 경합 보강

### 🔒 Worker 중복 실행 방지
- `PENDING -> GENERATING` 전이를 atomic update로 처리해 중복 worker의 AI 호출 진입 차단
- `GENERATING -> COMPLETED` 완료 claim을 atomic update로 처리해 첫 완료 worker만 피드백 저장
- 늦은 worker는 저장/실패 마킹/SSE 전송 없이 종료
- 피드백 저장 실패는 `FAILED`로 마킹하지 않고 stale recovery가 재처리할 수 있도록 유지

### ♻️ Stale recovery
- `StaleFeedbackRecoveryJob`으로 오래된 `PENDING/GENERATING` 피드백 작업 복구
- stale 기준 시간을 `interview.feedback.stale-threshold-minutes` 설정값으로 분리
- worker interrupt는 사용자-visible 실패가 아닌 중단 신호로 처리해 stale recovery에 맡김

### 🧪 부하 테스트
- 비동기 피드백 처리 검증용 k6 시나리오 추가
- 답변 제출 API가 AI 호출과 분리되어 빠르게 응답하는지 검증
- DB ping 시나리오를 함께 실행해 connection pool 고갈 여부 확인

## 🌐 API

- `POST /api/interviews/:sessionId/answer`
  - 마지막 답변 제출 시 `FEEDBACK_PENDING` 반환
  - 피드백 생성은 비동기로 진행
- `GET /api/interviews/:sessionId/feedback/events`
  - 피드백 상태 SSE 스트리밍
  - `status` 이벤트로 `PENDING`, `GENERATING`, `COMPLETED`, `FAILED` 상태 전달
- `GET /api/interviews/:sessionId/feedback`
  - 피드백 상태 조회
  - 생성 중이면 `202 Accepted`, 완료/실패 시 최종 상태 반환
- `POST /api/interviews/:sessionId/feedback/retry`
  - 실패한 피드백 생성 재시도

## 가이드

### 피드백 생성 플로우
1. `POST /api/interviews/:sessionId/answer`
   - 마지막 답변이면 `FEEDBACK_PENDING` 반환
2. `GET /api/interviews/:sessionId/feedback/events`
   - `GENERATING` 상태 이벤트 수신
   - 완료 시 `COMPLETED` 상태 이벤트 수신 후 SSE 종료
3. SSE timeout/error 또는 유실 시 `GET /api/interviews/:sessionId/feedback`로 DB 상태 조회

### 설정
```yaml
interview:
  feedback:
    stale-threshold-minutes: 6
```

환경 변수로도 조정할 수 있습니다.

```text
INTERVIEW_FEEDBACK_STALE_THRESHOLD_MINUTES=6
```

### k6 실행
```bash
mkdir -p results
k6 run loadtest/scenario-c-async-feedback.js
```

## 알아두어야 할 점
- SSE emitter는 현재 인스턴스 메모리에 저장되므로, 서버를 여러 대로 확장하기 전 Redis Pub/Sub 등 cross-instance delivery가 필요합니다.
- SSE는 실시간 UX 채널이고 최종 source of truth는 DB입니다.
- AI 중복 호출 자체는 현재 단계에서 허용하고, 추후 latency/비용 모니터링 후 token/lease 도입 여부를 판단합니다.
- stale recovery는 오래된 `PENDING/GENERATING` 세션을 다시 `PENDING`으로 돌리고 이벤트를 재발행합니다.

## 테스트
- `./gradlew test` 통과

## 다음에 해야 할 작업
- [ ] SSE 수평 확장 전 Redis Pub/Sub 기반 status event fanout 검토
- [ ] AI 피드백 생성 latency와 stale recovery 발생 빈도 모니터링
- [ ] 필요 시 generation attempt token/lease 도입 검토
