### PR TITLE
[fix] 결제 Outbox 보안 및 처리 안정성 개선

### DIFF
--- a/src/main/java/app/mockly/domain/payment/client/PortOneService.java
+++ b/src/main/java/app/mockly/domain/payment/client/PortOneService.java
@@ -33,7 +33,7 @@ public class PortOneService {
      * 빌링키 조회 및 검증
      */
     public BillingKeyInfo getBillingKey(String billingKey) {
-        log.info("PortOne Billing Key 조회: {}", billingKey);
+        log.info("PortOne 빌링키 조회 시작");
 
         try {
             return portOneClient.getPayment().getBillingKey()
@@ -41,7 +41,7 @@ public class PortOneService {
                     .orTimeout(3, TimeUnit.SECONDS)
                     .join();
         } catch (Exception e) {
-            log.error("빌링키 조회 실패: {}", billingKey, e);
+            log.error("빌링키 조회 실패", e);
             // TODO: 다른 Exception으로 만들 필요가 있는지 확인 필요
             throw new BusinessException(ApiStatusCode.BAD_REQUEST, "유효하지 않은 빌링키입니다.");
         }
@@ -57,7 +57,7 @@ public class PortOneService {
             Currency currency,
             PaymentAmountInput amount
     ) {
-        log.info("Billing Key 결제 시작 - paymentId: {}, billingKey: {}", paymentId, billingKey);
+        log.info("빌링키 결제 시작 - paymentId: {}", paymentId);
 
         try {
             return portOneClient.getPayment().payWithBillingKey(

--- a/src/main/java/app/mockly/domain/payment/dto/outbox/CreateSchedulePayload.java
+++ b/src/main/java/app/mockly/domain/payment/dto/outbox/CreateSchedulePayload.java
@@ -1,0 +1,6 @@
+package app.mockly.domain.payment.dto.outbox;
+
+public record CreateSchedulePayload(
+        Long paymentMethodId
+) {
+}

--- a/src/main/java/app/mockly/domain/payment/entity/OutboxEvent.java
+++ b/src/main/java/app/mockly/domain/payment/entity/OutboxEvent.java
@@ -1,11 +1,7 @@
 package app.mockly.domain.payment.entity;
 
 import app.mockly.global.common.BaseEntity;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.persistence.*;
-import java.util.Map;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -17,8 +13,6 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class OutboxEvent extends BaseEntity {
-
-    private static final ObjectMapper objectMapper = new ObjectMapper();
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -46,33 +40,15 @@ public class OutboxEvent extends BaseEntity {
     @Column(length = 500)
     private String failReason;
 
-    public static OutboxEvent scheduleCreate(Long subscriptionId, String billingKey) {
-        try {
-            Map<String, Object> payloadMap = Map.of(
-                    "subscriptionId", subscriptionId,
-                    "billingKey", billingKey
-            );
-            String payload = objectMapper.writeValueAsString(payloadMap);
-            OutboxEvent event = new OutboxEvent();
-            event.aggregateType = "SUBSCRIPTION";
-            event.aggregateId = subscriptionId;
-            event.eventType = "SCHEDULE_CREATE";
-            event.payload = payload;
-            event.status = OutboxEventStatus.PENDING;
-            event.retryCount = 0;
-            return event;
-        } catch (JsonProcessingException e) {
-            throw new IllegalArgumentException("OutboxEvent payload 직렬화 실패", e);
-        }
-    }
-
-    public String extractBillingKey() {
-        try {
-            JsonNode node = objectMapper.readTree(payload);
-            return node.get("billingKey").asText();
-        } catch (JsonProcessingException e) {
-            throw new IllegalStateException("Outbox payload 파싱 실패", e);
-        }
+    public static OutboxEvent createSchedule(Long subscriptionId, String payload) {
+        OutboxEvent event = new OutboxEvent();
+        event.aggregateType = "SUBSCRIPTION";
+        event.aggregateId = subscriptionId;
+        event.eventType = "SCHEDULE_CREATE";
+        event.payload = payload;
+        event.status = OutboxEventStatus.PENDING;
+        event.retryCount = 0;
+        return event;
     }
 
     public void markAsProcessed() {

--- a/src/main/java/app/mockly/domain/payment/repository/OutboxEventRepository.java
+++ b/src/main/java/app/mockly/domain/payment/repository/OutboxEventRepository.java
@@ -2,14 +2,30 @@ package app.mockly.domain.payment.repository;
 
 import app.mockly.domain.payment.entity.OutboxEvent;
 import app.mockly.domain.payment.entity.OutboxEventStatus;
+import jakarta.persistence.LockModeType;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.Optional;
 
 public interface OutboxEventRepository extends JpaRepository<OutboxEvent, Long> {
 
-    List<OutboxEvent> findTop20ByStatusOrderByCreatedAtAsc(OutboxEventStatus status);
+    @Query("""
+            SELECT event.id
+            FROM OutboxEvent event
+            WHERE event.status = :status
+            ORDER BY event.createdAt ASC
+            """)
+    List<Long> findIdsByStatusOrderByCreatedAtAsc(
+            @Param("status") OutboxEventStatus status,
+            Pageable pageable
+    );
 
-    Optional<OutboxEvent> findByAggregateIdAndEventTypeAndStatus(Long aggregateId, String eventType, OutboxEventStatus status);
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT event FROM OutboxEvent event WHERE event.id = :eventId")
+    Optional<OutboxEvent> findByIdForUpdate(@Param("eventId") Long eventId);
 }

--- a/src/main/java/app/mockly/domain/payment/scheduler/NonRetryableOutboxException.java
+++ b/src/main/java/app/mockly/domain/payment/scheduler/NonRetryableOutboxException.java
@@ -1,0 +1,20 @@
+package app.mockly.domain.payment.scheduler;
+
+public class NonRetryableOutboxException extends RuntimeException {
+
+    private final String failureCode;
+
+    public NonRetryableOutboxException(String failureCode, String message) {
+        super(message);
+        this.failureCode = failureCode;
+    }
+
+    public NonRetryableOutboxException(String failureCode, String message, Throwable cause) {
+        super(message, cause);
+        this.failureCode = failureCode;
+    }
+
+    public String getFailureCode() {
+        return failureCode;
+    }
+}

--- a/src/main/java/app/mockly/domain/payment/scheduler/OutboxEventProcessor.java
+++ b/src/main/java/app/mockly/domain/payment/scheduler/OutboxEventProcessor.java
@@ -1,14 +1,12 @@
 package app.mockly.domain.payment.scheduler;
 
-import app.mockly.domain.payment.entity.OutboxEvent;
 import app.mockly.domain.payment.entity.OutboxEventStatus;
 import app.mockly.domain.payment.repository.OutboxEventRepository;
-import app.mockly.domain.product.service.SubscriptionService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
@@ -16,31 +14,22 @@ import java.util.List;
 @Component
 @RequiredArgsConstructor
 public class OutboxEventProcessor {
-    private static final int MAX_RETRY_COUNT = 5;
 
     private final OutboxEventRepository outboxEventRepository;
-    private final SubscriptionService subscriptionService;
+    private final OutboxEventWorker outboxEventWorker;
 
     @Scheduled(fixedDelay = 60000)
-    @Transactional
     public void processOutboxEvents() {
-        List<OutboxEvent> events = outboxEventRepository.findTop20ByStatusOrderByCreatedAtAsc(OutboxEventStatus.PENDING);
+        List<Long> eventIds = outboxEventRepository.findIdsByStatusOrderByCreatedAtAsc(
+                OutboxEventStatus.PENDING,
+                PageRequest.of(0, 20)
+        );
 
-        for (OutboxEvent event : events) {
+        for (Long eventId : eventIds) {
             try {
-                if ("SCHEDULE_CREATE".equals(event.getEventType())) {
-                    subscriptionService.processScheduleCreation(event.getAggregateId());
-                }
+                outboxEventWorker.process(eventId);
             } catch (Exception e) {
-                event.recordRetryFailure(e.getMessage());
-                if (event.getRetryCount() >= MAX_RETRY_COUNT) {
-                    event.markAsFailed(e.getMessage());
-                    log.error("Outbox 이벤트 최종 실패 - eventId: {}, aggregateId: {}",
-                            event.getId(), event.getAggregateId(), e);
-                } else {
-                    log.warn("Outbox 이벤트 재시도 실패 ({}/{}) - eventId: {}, aggregateId: {}",
-                            event.getRetryCount(), MAX_RETRY_COUNT, event.getId(), event.getAggregateId(), e);
-                }
+                log.error("Outbox worker 실행 실패 - eventId: {}", eventId, e);
             }
         }
     }

--- a/src/main/java/app/mockly/domain/payment/scheduler/OutboxEventTransactionHelper.java
+++ b/src/main/java/app/mockly/domain/payment/scheduler/OutboxEventTransactionHelper.java
@@ -1,0 +1,61 @@
+package app.mockly.domain.payment.scheduler;
+
+import app.mockly.domain.payment.entity.OutboxEvent;
+import app.mockly.domain.payment.entity.OutboxEventStatus;
+import app.mockly.domain.payment.repository.OutboxEventRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class OutboxEventTransactionHelper {
+
+    private final OutboxEventRepository outboxEventRepository;
+    private final ScheduleCreationHandler scheduleCreationHandler;
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void processEvent(Long eventId) {
+        OutboxEvent event = findPendingEvent(eventId);
+        if (event == null) {
+            return;
+        }
+        if (!"SCHEDULE_CREATE".equals(event.getEventType())) {
+            throw new NonRetryableOutboxException(
+                    "UNSUPPORTED_EVENT_TYPE",
+                    "지원하지 않는 Outbox 이벤트 타입입니다."
+            );
+        }
+
+        scheduleCreationHandler.handle(event);
+        event.markAsProcessed();
+    }
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void markAsFailed(Long eventId, String reason) {
+        OutboxEvent event = findPendingEvent(eventId);
+        if (event != null) {
+            event.markAsFailed(reason);
+        }
+    }
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void recordRetryFailure(Long eventId, String reason, int maxRetryCount) {
+        OutboxEvent event = findPendingEvent(eventId);
+        if (event == null) {
+            return;
+        }
+
+        event.recordRetryFailure(reason);
+        if (event.getRetryCount() >= maxRetryCount) {
+            event.markAsFailed(reason);
+        }
+    }
+
+    private OutboxEvent findPendingEvent(Long eventId) {
+        return outboxEventRepository.findByIdForUpdate(eventId)
+                .filter(event -> event.getStatus() == OutboxEventStatus.PENDING)
+                .orElse(null);
+    }
+}

--- a/src/main/java/app/mockly/domain/payment/scheduler/OutboxEventWorker.java
+++ b/src/main/java/app/mockly/domain/payment/scheduler/OutboxEventWorker.java
@@ -1,0 +1,28 @@
+package app.mockly.domain.payment.scheduler;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class OutboxEventWorker {
+
+    private static final int MAX_RETRY_COUNT = 5;
+
+    private final OutboxEventTransactionHelper transactionHelper;
+
+    public void process(Long eventId) {
+        try {
+            transactionHelper.processEvent(eventId);
+        } catch (NonRetryableOutboxException e) {
+            transactionHelper.markAsFailed(eventId, e.getFailureCode());
+            log.error("Outbox 이벤트 영구 실패 - eventId: {}, failureCode: {}",
+                    eventId, e.getFailureCode(), e);
+        } catch (Exception e) {
+            transactionHelper.recordRetryFailure(eventId, e.getMessage(), MAX_RETRY_COUNT);
+            log.warn("Outbox 이벤트 처리 실패 - eventId: {}", eventId, e);
+        }
+    }
+}

--- a/src/main/java/app/mockly/domain/payment/scheduler/ScheduleCreationHandler.java
+++ b/src/main/java/app/mockly/domain/payment/scheduler/ScheduleCreationHandler.java
@@ -1,0 +1,80 @@
+package app.mockly.domain.payment.scheduler;
+
+import app.mockly.domain.payment.dto.outbox.CreateSchedulePayload;
+import app.mockly.domain.payment.entity.PaymentMethod;
+import app.mockly.domain.payment.repository.PaymentMethodRepository;
+import app.mockly.domain.product.entity.Subscription;
+import app.mockly.domain.product.repository.SubscriptionRepository;
+import app.mockly.domain.product.service.SubscriptionService;
+import app.mockly.domain.payment.entity.OutboxEvent;
+import app.mockly.global.common.ApiStatusCode;
+import app.mockly.global.exception.BusinessException;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class ScheduleCreationHandler {
+
+    private final PaymentMethodRepository paymentMethodRepository;
+    private final SubscriptionRepository subscriptionRepository;
+    private final SubscriptionService subscriptionService;
+    private final ObjectMapper objectMapper;
+
+    public void handle(OutboxEvent event) {
+        CreateSchedulePayload payload = deserializePayload(event.getPayload());
+        if (payload.paymentMethodId() == null) {
+            throw new NonRetryableOutboxException("INVALID_PAYLOAD", "paymentMethodId가 누락됐습니다.");
+        }
+
+        Subscription subscription = subscriptionRepository.findById(event.getAggregateId())
+                .orElseThrow(() -> new NonRetryableOutboxException(
+                        "SUBSCRIPTION_NOT_FOUND",
+                        "구독을 찾을 수 없습니다."
+                ));
+        if (subscription.getCurrentPaymentScheduleId() != null) {
+            return;
+        }
+
+        PaymentMethod paymentMethod = paymentMethodRepository.findById(payload.paymentMethodId())
+                .orElseThrow(() -> new NonRetryableOutboxException(
+                        "PAYMENT_METHOD_NOT_FOUND",
+                        "결제 수단을 찾을 수 없습니다."
+                ));
+        if (!paymentMethod.getUser().getId().equals(subscription.getUserId())) {
+            throw new NonRetryableOutboxException(
+                    "PAYMENT_METHOD_OWNER_MISMATCH",
+                    "구독 소유자의 결제 수단이 아닙니다."
+            );
+        }
+        if (!paymentMethod.isActive()) {
+            throw new NonRetryableOutboxException(
+                    "PAYMENT_METHOD_INACTIVE",
+                    "비활성화된 결제 수단입니다."
+            );
+        }
+
+        try {
+            subscriptionService.createFirstPaymentSchedule(subscription, paymentMethod.getBillingKey());
+        } catch (BusinessException e) {
+            if (e.getStatusCode() == ApiStatusCode.DUPLICATE_RESOURCE) {
+                throw new NonRetryableOutboxException(
+                        "PAYMENT_SCHEDULE_ALREADY_EXISTS",
+                        "PortOne에 결제 스케줄이 이미 존재합니다.",
+                        e
+                );
+            }
+            throw e;
+        }
+    }
+
+    private CreateSchedulePayload deserializePayload(String payload) {
+        try {
+            return objectMapper.readValue(payload, CreateSchedulePayload.class);
+        } catch (JsonProcessingException e) {
+            throw new NonRetryableOutboxException("INVALID_PAYLOAD", "Outbox payload 역직렬화 실패", e);
+        }
+    }
+}

--- a/src/main/java/app/mockly/domain/payment/service/WebhookService.java
+++ b/src/main/java/app/mockly/domain/payment/service/WebhookService.java
@@ -85,20 +85,20 @@ public class WebhookService {
             subscription.activate();
             try {
                 subscriptionService.createFirstPaymentSchedule(subscription, billingKey);
-                log.info("첫 결제 완료 및 구독 활성화 (Webhook 보정): {}, billingKey: {}", subscription.getId(), billingKey);
+                log.info("첫 결제 완료 및 구독 활성화 (Webhook 보정): {}", subscription.getId());
             } catch (Exception e) {
                 subscription.markAsPastDue();
-                log.error("첫 결제 스케줄 생성 실패, 구독 PAST_DUE 전환 - subscriptionId: {}, billingKey: {}",
-                        subscription.getId(), billingKey, e);
+                log.error("첫 결제 스케줄 생성 실패, 구독 PAST_DUE 전환 - subscriptionId: {}",
+                        subscription.getId(), e);
             }
         } else if (subscription.isActive() && !subscription.isCanceled()) { // 갱신 결제: 구독 갱신 + 다음 스케줄 생성
             try {
                 subscriptionService.renewSubscription(subscription, billingKey);
-                log.info("구독 갱신 완료 (Webhook): {}, billingKey: {}", subscription.getId(), billingKey);
+                log.info("구독 갱신 완료 (Webhook): {}", subscription.getId());
             } catch (Exception e) {
                 subscription.markAsPastDue();
-                log.error("구독 갱신 실패, 구독 PAST_DUE 전환 - subscriptionId: {}, billingKey: {}",
-                        subscription.getId(), billingKey, e);
+                log.error("구독 갱신 실패, 구독 PAST_DUE 전환 - subscriptionId: {}",
+                        subscription.getId(), e);
             }
         }
     }

--- a/src/main/java/app/mockly/domain/product/controller/SubscriptionController.java
+++ b/src/main/java/app/mockly/domain/product/controller/SubscriptionController.java
@@ -9,7 +9,6 @@ import app.mockly.domain.product.service.SubscriptionService;
 import app.mockly.global.common.ApiResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -17,7 +16,6 @@ import org.springframework.web.bind.annotation.*;
 
 import java.util.UUID;
 
-@Slf4j
 @RestController
 @RequestMapping("/api/subscriptions")
 @RequiredArgsConstructor
@@ -29,12 +27,6 @@ public class SubscriptionController {
             @RequestBody @Valid CreateSubscriptionRequest request,
             @AuthenticationPrincipal UUID userId) {
         CreateSubscriptionResponse response = subscriptionService.createSubscription(userId, request); // tx1: 결제 + Outbox 저장
-
-        try {
-            subscriptionService.processScheduleCreation(response.id()); // tx2: 스케줄 생성 (Outbox Polling)
-        } catch (Exception e) {
-            log.error("스케줄 생성 실패, Outbox 재시도 예정 - subscriptionId: {}", response.id(), e);
-        }
 
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(ApiResponse.success(response));

--- a/src/main/java/app/mockly/domain/product/service/SubscriptionService.java
+++ b/src/main/java/app/mockly/domain/product/service/SubscriptionService.java
@@ -213,8 +213,8 @@ public class SubscriptionService {
         );
         String scheduleId = paymentScheduleService.createSchedule(subscription, billingKey, nextPeriodStart, nextPeriodEnd);
 
-        log.info("구독 갱신 완료 - subscriptionId: {}, scheduleId: {}, billingKey: {}, 현재 기간: {} ~ {}, 다음 결제일: {}",
-                subscription.getId(), scheduleId, billingKey, subscription.getCurrentPeriodStart(), subscription.getCurrentPeriodEnd(), nextPeriodStart);
+        log.info("구독 갱신 완료 - subscriptionId: {}, scheduleId: {}, 현재 기간: {} ~ {}, 다음 결제일: {}",
+                subscription.getId(), scheduleId, subscription.getCurrentPeriodStart(), subscription.getCurrentPeriodEnd(), nextPeriodStart);
     }
 
     private Subscription validateAndGetSubscription(UUID userId, Long subscriptionId) {

--- a/src/main/java/app/mockly/domain/product/service/SubscriptionService.java
+++ b/src/main/java/app/mockly/domain/product/service/SubscriptionService.java
@@ -1,6 +1,7 @@
 package app.mockly.domain.product.service;
 
 import app.mockly.domain.payment.client.PortOneService;
+import app.mockly.domain.payment.dto.outbox.CreateSchedulePayload;
 import app.mockly.domain.payment.entity.*;
 import app.mockly.domain.payment.repository.InvoiceRepository;
 import app.mockly.domain.payment.repository.OutboxEventRepository;
@@ -15,6 +16,8 @@ import app.mockly.domain.product.repository.SubscriptionPlanRepository;
 import app.mockly.domain.product.repository.SubscriptionRepository;
 import app.mockly.global.common.ApiStatusCode;
 import app.mockly.global.exception.BusinessException;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.portone.sdk.server.common.PaymentAmountInput;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -39,6 +42,7 @@ public class SubscriptionService {
     private final InvoiceRepository invoiceRepository;
     private final PaymentRepository paymentRepository;
     private final OutboxEventRepository outboxEventRepository;
+    private final ObjectMapper objectMapper;
 
     @Transactional
     public CreateSubscriptionResponse createSubscription(UUID userId, CreateSubscriptionRequest request) {
@@ -99,7 +103,8 @@ public class SubscriptionService {
         Payment payment = Payment.create(invoice, subscriptionPlan.getPrice(), subscriptionPlan.getCurrency());
         paymentRepository.save(payment);
 
-        outboxEventRepository.save(OutboxEvent.scheduleCreate(subscription.getId(), billingKey));
+        CreateSchedulePayload outboxPayload = new CreateSchedulePayload(paymentMethodId);
+        outboxEventRepository.save(OutboxEvent.createSchedule(subscription.getId(), serializeOutboxPayload(outboxPayload)));
 
         // 결제 요청
         try {
@@ -193,36 +198,8 @@ public class SubscriptionService {
         );
         String scheduleId = paymentScheduleService.createSchedule(subscription, billingKey, nextPeriodStart, nextPeriodEnd);
 
-        log.info("첫 결제 스케줄 생성 완료 - subscriptionId: {}, scheduleId: {}, billingKey: {}, 다음 결제일: {}",
-                subscription.getId(), scheduleId, billingKey, nextPeriodStart);
-    }
-
-    @Transactional
-    public void processScheduleCreation(Long subscriptionId) {
-        OutboxEvent event = outboxEventRepository.findByAggregateIdAndEventTypeAndStatus(subscriptionId, "SCHEDULE_CREATE", OutboxEventStatus.PENDING)
-                .orElse(null);
-        if (event == null) return;
-
-        Subscription subscription = subscriptionRepository.findById(subscriptionId)
-                .orElseThrow(() -> new BusinessException(ApiStatusCode.RESOURCE_NOT_FOUND, "구독을 찾을 수 없습니다."));
-        // 이미 스케줄이 생성되어 있는 경우, 중복 방지 (ex. 기본 결제 수단 변경)
-        if (subscription.getCurrentPaymentScheduleId() != null) {
-            event.markAsProcessed();
-            return;
-        }
-
-        String billingKey = event.extractBillingKey();
-
-        try {
-            createFirstPaymentSchedule(subscription, billingKey);
-            event.markAsProcessed();
-        } catch (BusinessException e) {
-            if (e.getStatusCode() == ApiStatusCode.DUPLICATE_RESOURCE) {
-                log.warn("PortOne에 스케줄 존재하나 DB에 scheduleId 없음 - subscriptionId: {}", subscriptionId);
-                event.markAsFailed("PAYMENT_SCHEDULE_ALREADY_EXISTS - 수동 확인 필요");
-            }
-            throw e;
-        }
+        log.info("첫 결제 스케줄 생성 완료 - subscriptionId: {}, scheduleId: {}, 다음 결제일: {}",
+                subscription.getId(), scheduleId, nextPeriodStart);
     }
 
     @Transactional
@@ -283,4 +260,13 @@ public class SubscriptionService {
             case LIFETIME -> null;
         };
     }
+
+    private String serializeOutboxPayload(CreateSchedulePayload payload) {
+        try {
+            return objectMapper.writeValueAsString(payload);
+        } catch (JsonProcessingException e) {
+            throw new IllegalStateException("Outbox payload 직렬화 실패", e);
+        }
+    }
+
 }

--- a/src/main/java/app/mockly/domain/product/service/SubscriptionService.java
+++ b/src/main/java/app/mockly/domain/product/service/SubscriptionService.java
@@ -153,15 +153,9 @@ public class SubscriptionService {
 
         // 결제 스케줄 취소
         if (subscription.getCurrentPaymentScheduleId() != null) {
-            try {
-                portOneService.revokePaymentSchedule(subscription.getCurrentPaymentScheduleId());
-                log.info("결제 스케줄 취소 완료 - subscriptionId: {}, scheduleId: {}",
-                        subscriptionId, subscription.getCurrentPaymentScheduleId());
-            } catch (Exception e) {
-                log.error("결제 스케줄 취소 실패 - subscriptionId: {}, scheduleId: {}",
-                        subscriptionId, subscription.getCurrentPaymentScheduleId(), e);
-                // 실패해도 구독은 취소 처리 (스케줄은 수동 정리 필요)
-            }
+            portOneService.revokePaymentSchedule(subscription.getCurrentPaymentScheduleId());
+            log.info("결제 스케줄 취소 완료 - subscriptionId: {}, scheduleId: {}",
+                    subscriptionId, subscription.getCurrentPaymentScheduleId());
         }
 
         subscription.cancel();

--- a/src/test/java/app/mockly/domain/payment/entity/OutboxEventTest.java
+++ b/src/test/java/app/mockly/domain/payment/entity/OutboxEventTest.java
@@ -1,0 +1,31 @@
+package app.mockly.domain.payment.entity;
+
+import app.mockly.domain.payment.dto.outbox.CreateSchedulePayload;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class OutboxEventTest {
+
+    @Test
+    @DisplayName("결제 스케줄 payload는 결제수단 ID만 가진다")
+    void createSchedulePayloadContainsOnlyPaymentMethodId() {
+        assertThat(CreateSchedulePayload.class.getRecordComponents())
+                .extracting(component -> component.getName())
+                .containsExactly("paymentMethodId");
+    }
+
+    @Test
+    @DisplayName("결제 스케줄 생성 이벤트는 전달받은 payload를 저장한다")
+    void createScheduleStoresSerializedPayload() {
+        String payload = "{\"subscriptionId\":10,\"paymentMethodId\":20}";
+
+        OutboxEvent event = OutboxEvent.createSchedule(10L, payload);
+
+        assertThat(event.getPayload()).isEqualTo(payload);
+        assertThat(event.getAggregateId()).isEqualTo(10L);
+        assertThat(event.getEventType()).isEqualTo("SCHEDULE_CREATE");
+        assertThat(event.getStatus()).isEqualTo(OutboxEventStatus.PENDING);
+    }
+}

--- a/src/test/java/app/mockly/domain/payment/scheduler/OutboxEventProcessorTest.java
+++ b/src/test/java/app/mockly/domain/payment/scheduler/OutboxEventProcessorTest.java
@@ -1,0 +1,81 @@
+package app.mockly.domain.payment.scheduler;
+
+import app.mockly.domain.payment.entity.OutboxEventStatus;
+import app.mockly.domain.payment.repository.OutboxEventRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+class OutboxEventProcessorTest {
+
+    @Test
+    @DisplayName("Outbox 스케줄러는 배치 트랜잭션을 열지 않는다")
+    void schedulerDoesNotOpenBatchTransaction() throws NoSuchMethodException {
+        Transactional transactional = OutboxEventProcessor.class
+                .getDeclaredMethod("processOutboxEvents")
+                .getAnnotation(Transactional.class);
+
+        assertThat(transactional).isNull();
+    }
+
+    @Test
+    @DisplayName("Outbox 스케줄러는 구독 서비스를 직접 실행하지 않는다")
+    void schedulerDoesNotDependOnSubscriptionService() {
+        assertThat(OutboxEventProcessor.class.getDeclaredFields())
+                .extracting(field -> field.getType().getName())
+                .doesNotContain("app.mockly.domain.product.service.SubscriptionService");
+    }
+
+    @Test
+    @DisplayName("Outbox repository는 스케줄러에 entity가 아닌 ID를 반환한다")
+    void repositoryExposesPendingEventIdProjection() throws NoSuchMethodException {
+        assertThat(OutboxEventRepository.class.getMethod(
+                "findIdsByStatusOrderByCreatedAtAsc",
+                OutboxEventStatus.class,
+                Pageable.class
+        ).getReturnType()).isEqualTo(java.util.List.class);
+    }
+
+    @Test
+    @DisplayName("스케줄러는 조회한 이벤트 ID를 worker에 전달한다")
+    void schedulerDispatchesEventIdsToWorker() {
+        OutboxEventRepository repository = mock(OutboxEventRepository.class);
+        OutboxEventWorker worker = mock(OutboxEventWorker.class);
+        OutboxEventProcessor processor = new OutboxEventProcessor(repository, worker);
+        given(repository.findIdsByStatusOrderByCreatedAtAsc(
+                OutboxEventStatus.PENDING,
+                PageRequest.of(0, 20)
+        )).willReturn(java.util.List.of(1L, 2L));
+
+        processor.processOutboxEvents();
+
+        verify(worker).process(1L);
+        verify(worker).process(2L);
+    }
+
+    @Test
+    @DisplayName("한 이벤트 worker가 실패해도 다음 이벤트를 계속 전달한다")
+    void schedulerContinuesAfterWorkerFailure() {
+        OutboxEventRepository repository = mock(OutboxEventRepository.class);
+        OutboxEventWorker worker = mock(OutboxEventWorker.class);
+        OutboxEventProcessor processor = new OutboxEventProcessor(repository, worker);
+        given(repository.findIdsByStatusOrderByCreatedAtAsc(
+                OutboxEventStatus.PENDING,
+                PageRequest.of(0, 20)
+        )).willReturn(java.util.List.of(1L, 2L));
+        doThrow(new RuntimeException("retry state persistence failed"))
+                .when(worker).process(1L);
+
+        assertThatCode(processor::processOutboxEvents).doesNotThrowAnyException();
+        verify(worker).process(2L);
+    }
+}

--- a/src/test/java/app/mockly/domain/payment/scheduler/OutboxEventTransactionHelperBehaviorTest.java
+++ b/src/test/java/app/mockly/domain/payment/scheduler/OutboxEventTransactionHelperBehaviorTest.java
@@ -1,0 +1,83 @@
+package app.mockly.domain.payment.scheduler;
+
+import app.mockly.domain.payment.entity.OutboxEvent;
+import app.mockly.domain.payment.entity.OutboxEventStatus;
+import app.mockly.domain.payment.repository.OutboxEventRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class OutboxEventTransactionHelperBehaviorTest {
+
+    @Mock
+    private OutboxEventRepository outboxEventRepository;
+    @Mock
+    private ScheduleCreationHandler scheduleCreationHandler;
+    @InjectMocks
+    private OutboxEventTransactionHelper transactionHelper;
+
+    @Test
+    @DisplayName("이벤트 ID로 조회한 한 건을 처리하고 성공 상태로 변경한다")
+    void processEventMarksEventAsProcessed() {
+        OutboxEvent event = pendingEvent();
+        given(outboxEventRepository.findByIdForUpdate(1L)).willReturn(Optional.of(event));
+
+        transactionHelper.processEvent(1L);
+
+        verify(scheduleCreationHandler).handle(event);
+        assertThat(event.getStatus()).isEqualTo(OutboxEventStatus.PROCESSED);
+    }
+
+    @Test
+    @DisplayName("영구 오류는 별도 트랜잭션에서 실패 상태로 기록한다")
+    void markAsFailedUpdatesPendingEvent() {
+        OutboxEvent event = pendingEvent();
+        given(outboxEventRepository.findByIdForUpdate(1L)).willReturn(Optional.of(event));
+
+        transactionHelper.markAsFailed(1L, "INVALID_PAYLOAD");
+
+        assertThat(event.getStatus()).isEqualTo(OutboxEventStatus.FAILED);
+        assertThat(event.getFailReason()).isEqualTo("INVALID_PAYLOAD");
+    }
+
+    @Test
+    @DisplayName("일시 오류는 재시도 횟수를 증가시키고 PENDING 상태를 유지한다")
+    void recordRetryFailureKeepsEventPendingBeforeLimit() {
+        OutboxEvent event = pendingEvent();
+        given(outboxEventRepository.findByIdForUpdate(1L)).willReturn(Optional.of(event));
+
+        transactionHelper.recordRetryFailure(1L, "timeout", 5);
+
+        assertThat(event.getStatus()).isEqualTo(OutboxEventStatus.PENDING);
+        assertThat(event.getRetryCount()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("최대 재시도 횟수에 도달하면 최종 실패 상태로 변경한다")
+    void recordRetryFailureMarksEventFailedAtLimit() {
+        OutboxEvent event = pendingEvent();
+        for (int attempt = 0; attempt < 4; attempt++) {
+            event.recordRetryFailure("timeout");
+        }
+        given(outboxEventRepository.findByIdForUpdate(1L)).willReturn(Optional.of(event));
+
+        transactionHelper.recordRetryFailure(1L, "timeout", 5);
+
+        assertThat(event.getStatus()).isEqualTo(OutboxEventStatus.FAILED);
+        assertThat(event.getRetryCount()).isEqualTo(5);
+    }
+
+    private OutboxEvent pendingEvent() {
+        return OutboxEvent.createSchedule(10L, "{\"paymentMethodId\":20}");
+    }
+}

--- a/src/test/java/app/mockly/domain/payment/scheduler/OutboxEventTransactionHelperTest.java
+++ b/src/test/java/app/mockly/domain/payment/scheduler/OutboxEventTransactionHelperTest.java
@@ -1,0 +1,40 @@
+package app.mockly.domain.payment.scheduler;
+
+import app.mockly.domain.payment.repository.OutboxEventRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.lang.reflect.Method;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+class OutboxEventTransactionHelperTest {
+
+    @Test
+    @DisplayName("이벤트 처리와 실패 기록은 각각 새로운 트랜잭션에서 실행한다")
+    void operationsUseRequiresNewTransactions() throws NoSuchMethodException {
+        assertRequiresNew("processEvent", Long.class);
+        assertRequiresNew("markAsFailed", Long.class, String.class);
+        assertRequiresNew("recordRetryFailure", Long.class, String.class, int.class);
+    }
+
+    @Test
+    @DisplayName("이벤트별 처리 트랜잭션은 대상 이벤트를 잠금 조회한다")
+    void repositoryExposesEventLockQuery() {
+        assertThatCode(() -> OutboxEventRepository.class.getDeclaredMethod(
+                "findByIdForUpdate",
+                Long.class
+        )).doesNotThrowAnyException();
+    }
+
+    private void assertRequiresNew(String methodName, Class<?>... parameterTypes) throws NoSuchMethodException {
+        Method method = OutboxEventTransactionHelper.class.getDeclaredMethod(methodName, parameterTypes);
+        Transactional transactional = method.getAnnotation(Transactional.class);
+
+        assertThat(transactional).isNotNull();
+        assertThat(transactional.propagation()).isEqualTo(Propagation.REQUIRES_NEW);
+    }
+}

--- a/src/test/java/app/mockly/domain/payment/scheduler/OutboxEventTransactionIntegrationTest.java
+++ b/src/test/java/app/mockly/domain/payment/scheduler/OutboxEventTransactionIntegrationTest.java
@@ -1,0 +1,56 @@
+package app.mockly.domain.payment.scheduler;
+
+import app.mockly.domain.payment.entity.OutboxEvent;
+import app.mockly.domain.payment.entity.OutboxEventStatus;
+import app.mockly.domain.payment.repository.OutboxEventRepository;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.willThrow;
+
+@SpringBootTest
+class OutboxEventTransactionIntegrationTest {
+
+    @Autowired
+    private OutboxEventRepository outboxEventRepository;
+    @Autowired
+    private OutboxEventTransactionHelper transactionHelper;
+    @MockitoBean
+    private ScheduleCreationHandler scheduleCreationHandler;
+
+    @AfterEach
+    void tearDown() {
+        outboxEventRepository.deleteAll();
+    }
+
+    @Test
+    @DisplayName("처리 트랜잭션이 롤백돼도 재시도 상태는 별도 트랜잭션으로 저장한다")
+    void retryStatePersistsAfterProcessingTransactionRollback() {
+        OutboxEvent event = outboxEventRepository.saveAndFlush(
+                OutboxEvent.createSchedule(10L, "{\"paymentMethodId\":20}")
+        );
+        willThrow(new RuntimeException("temporary failure"))
+                .given(scheduleCreationHandler).handle(any(OutboxEvent.class));
+
+        assertThatThrownBy(() -> transactionHelper.processEvent(event.getId()))
+                .isInstanceOf(RuntimeException.class)
+                .hasMessage("temporary failure");
+
+        OutboxEvent rolledBack = outboxEventRepository.findById(event.getId()).orElseThrow();
+        assertThat(rolledBack.getStatus()).isEqualTo(OutboxEventStatus.PENDING);
+        assertThat(rolledBack.getRetryCount()).isZero();
+
+        transactionHelper.recordRetryFailure(event.getId(), "temporary failure", 5);
+
+        OutboxEvent retried = outboxEventRepository.findById(event.getId()).orElseThrow();
+        assertThat(retried.getStatus()).isEqualTo(OutboxEventStatus.PENDING);
+        assertThat(retried.getRetryCount()).isEqualTo(1);
+    }
+}

--- a/src/test/java/app/mockly/domain/payment/scheduler/OutboxEventWorkerTest.java
+++ b/src/test/java/app/mockly/domain/payment/scheduler/OutboxEventWorkerTest.java
@@ -1,0 +1,46 @@
+package app.mockly.domain.payment.scheduler;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+class OutboxEventWorkerTest {
+
+    @Test
+    @DisplayName("Outbox worker는 트랜잭션 helper를 통해 이벤트를 처리한다")
+    void workerDependsOnTransactionHelper() {
+        assertThat(OutboxEventWorker.class.getDeclaredFields())
+                .extracting(field -> field.getType().getSimpleName())
+                .contains("OutboxEventTransactionHelper");
+    }
+
+    @Test
+    @DisplayName("영구 오류는 재시도하지 않고 별도 트랜잭션으로 실패 기록한다")
+    void permanentFailureIsMarkedAsFailed() {
+        OutboxEventTransactionHelper transactionHelper = mock(OutboxEventTransactionHelper.class);
+        OutboxEventWorker worker = new OutboxEventWorker(transactionHelper);
+        doThrow(new NonRetryableOutboxException("INVALID_PAYLOAD", "잘못된 payload"))
+                .when(transactionHelper).processEvent(1L);
+
+        worker.process(1L);
+
+        verify(transactionHelper).markAsFailed(1L, "INVALID_PAYLOAD");
+    }
+
+    @Test
+    @DisplayName("일시 오류는 별도 트랜잭션으로 재시도 실패를 기록한다")
+    void transientFailureIsRecordedForRetry() {
+        OutboxEventTransactionHelper transactionHelper = mock(OutboxEventTransactionHelper.class);
+        OutboxEventWorker worker = new OutboxEventWorker(transactionHelper);
+        doThrow(new RuntimeException("temporary failure"))
+                .when(transactionHelper).processEvent(1L);
+
+        worker.process(1L);
+
+        verify(transactionHelper).recordRetryFailure(1L, "temporary failure", 5);
+    }
+}

--- a/src/test/java/app/mockly/domain/payment/scheduler/ScheduleCreationHandlerArchitectureTest.java
+++ b/src/test/java/app/mockly/domain/payment/scheduler/ScheduleCreationHandlerArchitectureTest.java
@@ -1,0 +1,27 @@
+package app.mockly.domain.payment.scheduler;
+
+import app.mockly.domain.payment.entity.OutboxEvent;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+class ScheduleCreationHandlerArchitectureTest {
+
+    @Test
+    @DisplayName("스케줄 생성 Outbox 소비 로직은 전용 handler가 담당한다")
+    void scheduleCreationHandlerExists() {
+        assertThatCode(() -> Class.forName(
+                "app.mockly.domain.payment.scheduler.ScheduleCreationHandler"
+        )).doesNotThrowAnyException();
+    }
+
+    @Test
+    @DisplayName("스케줄 생성 handler는 조회된 Outbox 이벤트를 직접 처리한다")
+    void handlerAcceptsOutboxEvent() {
+        assertThatCode(() -> ScheduleCreationHandler.class.getDeclaredMethod(
+                "handle",
+                OutboxEvent.class
+        )).doesNotThrowAnyException();
+    }
+}

--- a/src/test/java/app/mockly/domain/payment/scheduler/ScheduleCreationHandlerTest.java
+++ b/src/test/java/app/mockly/domain/payment/scheduler/ScheduleCreationHandlerTest.java
@@ -1,0 +1,138 @@
+package app.mockly.domain.payment.scheduler;
+
+import app.mockly.domain.auth.entity.User;
+import app.mockly.domain.payment.entity.OutboxEvent;
+import app.mockly.domain.payment.entity.PaymentMethod;
+import app.mockly.domain.payment.repository.PaymentMethodRepository;
+import app.mockly.domain.product.entity.Subscription;
+import app.mockly.domain.product.repository.SubscriptionRepository;
+import app.mockly.domain.product.service.SubscriptionService;
+import app.mockly.global.common.ApiStatusCode;
+import app.mockly.global.exception.BusinessException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willThrow;
+import static org.mockito.Mockito.mock;
+
+@ExtendWith(MockitoExtension.class)
+class ScheduleCreationHandlerTest {
+
+    @Mock
+    private PaymentMethodRepository paymentMethodRepository;
+    @Mock
+    private SubscriptionRepository subscriptionRepository;
+    @Mock
+    private SubscriptionService subscriptionService;
+
+    private ScheduleCreationHandler handler;
+    private Subscription subscription;
+
+    @BeforeEach
+    void setUp() {
+        handler = new ScheduleCreationHandler(
+                paymentMethodRepository,
+                subscriptionRepository,
+                subscriptionService,
+                new ObjectMapper()
+        );
+    }
+
+    @Test
+    @DisplayName("잘못된 payload는 영구 오류로 분류한다")
+    void malformedPayloadIsPermanentFailure() {
+        OutboxEvent event = OutboxEvent.createSchedule(1L, "not-json");
+
+        assertFailureCode(event, "INVALID_PAYLOAD");
+    }
+
+    @Test
+    @DisplayName("결제수단 ID가 누락된 payload는 영구 오류로 분류한다")
+    void missingPaymentMethodIdIsPermanentFailure() {
+        OutboxEvent event = OutboxEvent.createSchedule(1L, "{}");
+
+        assertFailureCode(event, "INVALID_PAYLOAD");
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 결제수단은 영구 오류로 분류한다")
+    void missingPaymentMethodIsPermanentFailure() {
+        OutboxEvent event = pendingEvent();
+        given(paymentMethodRepository.findById(20L)).willReturn(Optional.empty());
+
+        assertFailureCode(event, "PAYMENT_METHOD_NOT_FOUND");
+    }
+
+    @Test
+    @DisplayName("결제수단 소유자 불일치는 영구 오류로 분류한다")
+    void paymentMethodOwnerMismatchIsPermanentFailure() {
+        OutboxEvent event = pendingEvent();
+        PaymentMethod paymentMethod = mock(PaymentMethod.class);
+        User owner = mock(User.class);
+        given(paymentMethodRepository.findById(20L)).willReturn(Optional.of(paymentMethod));
+        given(paymentMethod.getUser()).willReturn(owner);
+        given(owner.getId()).willReturn(UUID.randomUUID());
+        given(subscription.getUserId()).willReturn(UUID.randomUUID());
+
+        assertFailureCode(event, "PAYMENT_METHOD_OWNER_MISMATCH");
+    }
+
+    @Test
+    @DisplayName("비활성 결제수단은 영구 오류로 분류한다")
+    void inactivePaymentMethodIsPermanentFailure() {
+        OutboxEvent event = pendingEvent();
+        PaymentMethod paymentMethod = paymentMethodOwnedBySubscription();
+        given(paymentMethod.isActive()).willReturn(false);
+
+        assertFailureCode(event, "PAYMENT_METHOD_INACTIVE");
+    }
+
+    @Test
+    @DisplayName("중복 PortOne 스케줄은 영구 오류로 분류한다")
+    void duplicateScheduleIsPermanentFailure() {
+        OutboxEvent event = pendingEvent();
+        PaymentMethod paymentMethod = paymentMethodOwnedBySubscription();
+        given(paymentMethod.isActive()).willReturn(true);
+        given(paymentMethod.getBillingKey()).willReturn("billing-key");
+        willThrow(new BusinessException(ApiStatusCode.DUPLICATE_RESOURCE, "중복 스케줄"))
+                .given(subscriptionService).createFirstPaymentSchedule(subscription, "billing-key");
+
+        assertFailureCode(event, "PAYMENT_SCHEDULE_ALREADY_EXISTS");
+    }
+
+    private OutboxEvent pendingEvent() {
+        OutboxEvent event = OutboxEvent.createSchedule(1L, "{\"paymentMethodId\":20}");
+        subscription = mock(Subscription.class);
+        given(subscriptionRepository.findById(1L)).willReturn(Optional.of(subscription));
+        given(subscription.getCurrentPaymentScheduleId()).willReturn(null);
+        return event;
+    }
+
+    private PaymentMethod paymentMethodOwnedBySubscription() {
+        UUID userId = UUID.randomUUID();
+        PaymentMethod paymentMethod = mock(PaymentMethod.class);
+        User owner = mock(User.class);
+        given(paymentMethodRepository.findById(20L)).willReturn(Optional.of(paymentMethod));
+        given(paymentMethod.getUser()).willReturn(owner);
+        given(owner.getId()).willReturn(userId);
+        given(subscription.getUserId()).willReturn(userId);
+        return paymentMethod;
+    }
+
+    private void assertFailureCode(OutboxEvent event, String expectedCode) {
+        assertThatThrownBy(() -> handler.handle(event))
+                .isInstanceOfSatisfying(NonRetryableOutboxException.class,
+                        exception -> assertThat(exception.getFailureCode()).isEqualTo(expectedCode));
+    }
+}

--- a/src/test/java/app/mockly/domain/product/controller/SubscriptionControllerTest.java
+++ b/src/test/java/app/mockly/domain/product/controller/SubscriptionControllerTest.java
@@ -34,8 +34,10 @@ import java.math.BigDecimal;
 
 import static com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper.document;
 import static com.epages.restdocs.apispec.ResourceDocumentation.resource;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willThrow;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -259,6 +261,30 @@ class SubscriptionControllerTest {
                 .andDo(document("subscription-cancel",
                         resource(SubscriptionDocs.cancelSuccess())
                 ));
+    }
+
+    @Test
+    @DisplayName("DELETE /api/subscriptions/{id} - 실패: 결제 예약 취소 실패 시 활성 구독 유지")
+    void cancelSubscription_ScheduleRevokeFailureKeepsSubscriptionActive() throws Exception {
+        Subscription subscription = Subscription.create(testUser.getId(), basicMonthlyPlan);
+        subscription.activate();
+        subscription.setCurrentPaymentScheduleId("schedule-to-revoke");
+        subscription = subscriptionRepository.save(subscription);
+
+        willThrow(new app.mockly.global.exception.BusinessException(
+                app.mockly.global.common.ApiStatusCode.INTERNAL_SERVER_ERROR,
+                "결제 예약 취소 도중 오류가 발생했습니다."
+        )).given(portOneService).revokePaymentSchedule("schedule-to-revoke");
+
+        mockMvc.perform(delete("/api/subscriptions/{id}", subscription.getId())
+                        .header("Authorization", "Bearer " + validAccessToken)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andDo(print())
+                .andExpect(status().isInternalServerError())
+                .andExpect(jsonPath("$.success").value(false));
+
+        Subscription persisted = subscriptionRepository.findById(subscription.getId()).orElseThrow();
+        assertThat(persisted.getStatus()).isEqualTo(SubscriptionStatus.ACTIVE);
     }
 
     @Test

--- a/src/test/java/app/mockly/security/SensitiveDataLoggingTest.java
+++ b/src/test/java/app/mockly/security/SensitiveDataLoggingTest.java
@@ -1,0 +1,43 @@
+package app.mockly.security;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class SensitiveDataLoggingTest {
+
+    private static final Pattern LOG_CALL = Pattern.compile(
+            "log\\.(?:trace|debug|info|warn|error)\\s*\\((?s:.*?)\\);"
+    );
+
+    @Test
+    @DisplayName("운영 로그에는 빌링키를 기록하지 않는다")
+    void productionLogsDoNotContainBillingKeys() throws IOException {
+        List<String> filesWithSensitiveLogs = new ArrayList<>();
+
+        try (var paths = Files.walk(Path.of("src/main/java"))) {
+            for (Path path : paths.filter(candidate -> candidate.toString().endsWith(".java")).toList()) {
+                String source = Files.readString(path);
+                Matcher matcher = LOG_CALL.matcher(source);
+                while (matcher.find()) {
+                    if (matcher.group().contains("billingKey")) {
+                        filesWithSensitiveLogs.add(path.toString());
+                    }
+                }
+            }
+        }
+
+        assertThat(filesWithSensitiveLogs)
+                .as("빌링키를 포함한 로그 호출이 있는 파일")
+                .isEmpty();
+    }
+}


### PR DESCRIPTION
## 개요

결제 스케줄 생성 과정에서 billing key가 Outbox payload와 운영 로그에 노출되던 문제를 개선했습니다.

Outbox 스케줄러의 전체 이벤트 처리가 하나의 트랜잭션에 묶여 있어 개별 이벤트의 실패가 다른 이벤트 처리와 상태 저장에 영향을 줄 수 있던 구조도 이벤트별 독립 트랜잭션으로 변경했습니다.

결제 예약 취소에 실패했는데 내부 구독만 취소 상태로 변경될 수 있던 문제를 보완해 외부 결제 예약과 내부 구독 상태의 정합성을 유지하도록 수정했습니다.

## 주요 변경사항

### 🔐 결제 민감정보 보호
- Outbox payload에서 billing key 제거
- Outbox에는 `paymentMethodId`만 저장하고 처리 시 결제수단을 다시 조회
- PortOne 조회·결제 및 Webhook 로그에서 billing key 값 제거
- 운영 코드에 billing key를 기록하는 로그가 다시 추가되지 않도록 회귀 테스트 적용

### 🔄 Outbox 이벤트별 트랜잭션 분리
- `OutboxEventProcessor`는 최대 20개의 PENDING 이벤트 ID만 조회
- 각 이벤트를 `OutboxEventWorker`에 전달해 독립적으로 처리
- 이벤트 처리와 상태 저장에 `REQUIRES_NEW` 트랜잭션 적용
- 이벤트 조회 시 비관적 락을 적용해 동일 이벤트의 동시 처리 방지
- 한 이벤트의 실패가 이후 이벤트 처리에 영향을 주지 않도록 분리

### ♻️ 재시도 및 영구 실패 처리
- 일시적인 외부 API 오류는 최대 5회까지 재시도
- 최대 재시도 횟수 도달 시 Outbox 이벤트를 `FAILED`로 전환
- 잘못된 payload, 존재하지 않는 구독·결제수단, 비활성 결제수단, 소유자 불일치, 미지원 이벤트 타입, 중복 스케줄은 즉시 영구 실패 처리

### ✅ 결제수단 검증
- 결제수단 존재 여부 검증
- 결제수단 활성 상태 검증
- 결제수단 소유자와 구독 사용자 일치 여부 검증
- 검증을 통과한 경우에만 billing key를 메모리에서 조회해 PortOne 스케줄 생성에 사용

### 🛑 구독 해지 정합성 보완
- PortOne 결제 예약 취소 실패 예외를 무시하지 않고 상위로 전달
- 외부 결제 예약 취소에 실패하면 내부 구독을 `CANCELED`로 변경하지 않음
- 구독을 `ACTIVE` 상태로 유지해 외부 예약과 내부 상태가 달라지는 문제 방지

## 🌐 API 동작 변경

### `POST /api/subscriptions`
- 구독, 첫 결제, Outbox 이벤트 저장까지만 요청 트랜잭션에서 수행
- PortOne 결제 스케줄 생성은 Outbox worker가 비동기로 처리
- API 응답 과정에서 스케줄 생성을 직접 실행하지 않음

### `DELETE /api/subscriptions/{id}`
- PortOne 결제 예약 취소에 실패하면 오류 응답 반환
- 실패한 경우 구독 상태는 `ACTIVE`로 유지

## 알아두어야 할 점
- 현재 Outbox 이벤트 타입은 `SCHEDULE_CREATE`만 지원합니다.
- `aggregateId`에는 이벤트 처리 대상인 `subscriptionId`가 저장됩니다.
- payload에는 스케줄 생성에 필요한 `paymentMethodId`만 저장됩니다.
- billing key는 Outbox와 로그에서는 제거했지만 `PaymentMethod` DB 컬럼 암호화는 후속 작업으로 진행해야 합니다.
- 영구 실패한 Outbox 이벤트는 운영 모니터링과 관리자 확인이 필요합니다.

## 테스트
- Outbox ID 기반 dispatch 테스트
- 이벤트별 독립 트랜잭션 테스트
- 비관적 락 및 중복 처리 방지 테스트
- 일시 오류 재시도 및 최대 재시도 테스트
- 잘못된 payload와 결제수단 소유권 검증 테스트
- billing key 로그 노출 방지 테스트
- 결제 예약 취소 실패 시 구독 상태 유지 테스트
- 전체 테스트 `107개` 실행
  - 실패: `0`
  - 오류: `0`
  - 스킵: `2`

```bash
./gradlew test --rerun-tasks
```

## 다음에 해야 할 작업
- [ ] PaymentMethod billing key DB 암호화
- [ ] Outbox FAILED 이벤트 모니터링 및 알림
- [ ] 구독 취소 요청 비동기 처리 여부 검토
- [ ] 계정 삭제 시 결제수단과 활성 구독 정리 정책 적용
