### PR TITLE
chore: GCP pre-prod 배포 환경 구성

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,11 @@ out/
 .vscode/
 
 .env
+.env.preprod
+.env.preprod.*
+!.env.preprod.example
 application*.yaml
+!src/main/resources/application-preprod.yaml
+.codex/
 *:Zone.Identifier
 .mcp.json

--- a/deploy/preprod/.env.preprod.example
+++ b/deploy/preprod/.env.preprod.example
@@ -1,0 +1,17 @@
+# Non-sensitive defaults
+POSTGRES_DB=mockly_preprod
+POSTGRES_USER=mockly_preprod
+REDIS_DATABASE=1
+INTERVIEW_FEEDBACK_STALE_THRESHOLD_MINUTES=6
+APP_IMAGE_TAG=local
+
+# Set only on the GCP VM. Never commit real values.
+POSTGRES_PASSWORD=<set-on-gcp>
+REDIS_PASSWORD=<copy-shared-redis-password-on-gcp>
+JWT_SECRET=<generate-separate-preprod-secret-on-gcp>
+GOOGLE_ANDROID_CLIENT_ID=<play-android-oauth-client-id>
+PORTONE_API_SECRET=<test-api-secret>
+PORTONE_STORE_ID=<test-store-id>
+PORTONE_CHANNEL_KEY=<test-channel-key>
+PORTONE_WEBHOOK_SECRET=<test-webhook-secret>
+OPENAI_API_KEY=<openai-api-key>

--- a/deploy/preprod/docker-compose.yml
+++ b/deploy/preprod/docker-compose.yml
@@ -1,0 +1,49 @@
+services:
+  mockly-server-preprod:
+    image: mockly-server-preprod:${APP_IMAGE_TAG:-latest}
+    build:
+      context: ../..
+      dockerfile: Dockerfile
+    container_name: mockly-server-preprod
+    restart: unless-stopped
+    mem_limit: 512m
+    cpus: 0.75
+    environment:
+      SPRING_PROFILES_ACTIVE: preprod
+      POSTGRES_HOST: mockly-postgres
+      POSTGRES_PORT: 5432
+      POSTGRES_DB: ${POSTGRES_DB}
+      POSTGRES_USER: ${POSTGRES_USER}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      REDIS_HOST: mockly-redis
+      REDIS_PORT: 6379
+      REDIS_PASSWORD: ${REDIS_PASSWORD}
+      REDIS_DATABASE: ${REDIS_DATABASE:-1}
+      JWT_SECRET: ${JWT_SECRET}
+      GOOGLE_ANDROID_CLIENT_ID: ${GOOGLE_ANDROID_CLIENT_ID}
+      PORTONE_API_SECRET: ${PORTONE_API_SECRET}
+      PORTONE_STORE_ID: ${PORTONE_STORE_ID}
+      PORTONE_CHANNEL_KEY: ${PORTONE_CHANNEL_KEY}
+      PORTONE_WEBHOOK_SECRET: ${PORTONE_WEBHOOK_SECRET}
+      OPENAI_API_KEY: ${OPENAI_API_KEY}
+      INTERVIEW_FEEDBACK_STALE_THRESHOLD_MINUTES: ${INTERVIEW_FEEDBACK_STALE_THRESHOLD_MINUTES:-6}
+    healthcheck:
+      test: ["CMD-SHELL", "curl -fsS http://localhost:8080/actuator/health | grep -q '\"status\":\"UP\"'"]
+      interval: 10s
+      timeout: 5s
+      retries: 12
+      start_period: 45s
+    labels:
+      - "traefik.enable=true"
+      - "traefik.docker.network=mockly-infra_mockly-network"
+      - "traefik.http.routers.mockly-preprod.rule=Host(`pre-prod.kancho.co`)"
+      - "traefik.http.routers.mockly-preprod.entrypoints=websecure"
+      - "traefik.http.routers.mockly-preprod.tls=true"
+      - "traefik.http.services.mockly-preprod.loadbalancer.server.port=8080"
+    networks:
+      - mockly-network
+
+networks:
+  mockly-network:
+    external: true
+    name: mockly-infra_mockly-network

--- a/deploy/preprod/seed.sql
+++ b/deploy/preprod/seed.sql
@@ -1,0 +1,150 @@
+BEGIN;
+
+INSERT INTO plan (name, description, features, billing_cycle, is_active, created_at, updated_at)
+VALUES
+    (
+        'Free',
+        'AI 면접 연습을 가볍게 체험해보세요',
+        '["AI 면접 연습 일 1회", "AI 기본 피드백 제공", "면접 결과 요약 제공", "면접 기록 7일 보관"]'::jsonb,
+        'MONTHLY',
+        true,
+        NOW(),
+        NOW()
+    ),
+    (
+        'Basic',
+        'AI와 함께 면접을 준비하는 가장 기본적인 플랜',
+        '["AI 면접 연습 일 5회", "AI 상세 피드백 제공", "면접 결과 비교 및 히스토리 관리", "면접 기록 무제한 보관", "음성 기반 AI 인터뷰 지원"]'::jsonb,
+        'MONTHLY',
+        true,
+        NOW(),
+        NOW()
+    ),
+    (
+        'Pro',
+        'AI 분석을 통해 면접 실력을 체계적으로 개선하세요',
+        '["AI 면접 연습 일 10회", "AI 심층 분석 리포트 제공", "개인 맞춤형 AI 피드백", "면접 결과 추이 분석", "음성 기반 AI 인터뷰 지원"]'::jsonb,
+        'MONTHLY',
+        true,
+        NOW(),
+        NOW()
+    )
+ON CONFLICT (name) DO UPDATE
+SET description = EXCLUDED.description,
+    features = EXCLUDED.features,
+    billing_cycle = EXCLUDED.billing_cycle,
+    is_active = EXCLUDED.is_active,
+    updated_at = NOW();
+
+INSERT INTO plan_price (plan_id, price, currency)
+SELECT id,
+       CASE name
+           WHEN 'Free' THEN 0
+           WHEN 'Basic' THEN 4900
+           WHEN 'Pro' THEN 9900
+       END,
+       'KRW'
+FROM plan
+WHERE name IN ('Free', 'Basic', 'Pro')
+ON CONFLICT (plan_id, currency) DO UPDATE
+SET price = EXCLUDED.price;
+
+UPDATE subscription_product
+SET name = source.name,
+    description = source.description,
+    features = source.features,
+    is_active = true,
+    updated_at = NOW()
+FROM (
+    VALUES
+        (
+            'FREE',
+            'Free',
+            'AI 면접 연습을 가볍게 체험해보세요',
+            '["AI 면접 연습 일 1회", "AI 기본 피드백 제공", "면접 결과 요약 제공", "면접 기록 7일 보관"]'::jsonb
+        ),
+        (
+            'BASIC',
+            'Basic',
+            'AI와 함께 면접을 준비하는 가장 기본적인 플랜',
+            '["AI 면접 연습 일 5회", "AI 상세 피드백 제공", "면접 결과 비교 및 히스토리 관리", "면접 기록 무제한 보관", "음성 기반 AI 인터뷰 지원"]'::jsonb
+        ),
+        (
+            'PRO',
+            'Pro',
+            'AI 분석을 통해 면접 실력을 체계적으로 개선하세요',
+            '["AI 면접 연습 일 10회", "AI 심층 분석 리포트 제공", "개인 맞춤형 AI 피드백", "면접 결과 추이 분석", "음성 기반 AI 인터뷰 지원"]'::jsonb
+        )
+) AS source(plan_tier, name, description, features)
+WHERE subscription_product.plan_tier::text = source.plan_tier;
+
+INSERT INTO subscription_product (
+    name,
+    description,
+    features,
+    plan_tier,
+    is_active,
+    created_at,
+    updated_at
+)
+SELECT source.name,
+       source.description,
+       source.features,
+       source.plan_tier,
+       true,
+       NOW(),
+       NOW()
+FROM (
+    VALUES
+        (
+            'FREE',
+            'Free',
+            'AI 면접 연습을 가볍게 체험해보세요',
+            '["AI 면접 연습 일 1회", "AI 기본 피드백 제공", "면접 결과 요약 제공", "면접 기록 7일 보관"]'::jsonb
+        ),
+        (
+            'BASIC',
+            'Basic',
+            'AI와 함께 면접을 준비하는 가장 기본적인 플랜',
+            '["AI 면접 연습 일 5회", "AI 상세 피드백 제공", "면접 결과 비교 및 히스토리 관리", "면접 기록 무제한 보관", "음성 기반 AI 인터뷰 지원"]'::jsonb
+        ),
+        (
+            'PRO',
+            'Pro',
+            'AI 분석을 통해 면접 실력을 체계적으로 개선하세요',
+            '["AI 면접 연습 일 10회", "AI 심층 분석 리포트 제공", "개인 맞춤형 AI 피드백", "면접 결과 추이 분석", "음성 기반 AI 인터뷰 지원"]'::jsonb
+        )
+) AS source(plan_tier, name, description, features)
+WHERE NOT EXISTS (
+    SELECT 1
+    FROM subscription_product existing
+    WHERE existing.plan_tier::text = source.plan_tier
+);
+
+INSERT INTO subscription_plan (product_id, price, currency, billing_cycle)
+SELECT id,
+       CASE plan_tier::text
+           WHEN 'FREE' THEN 0
+           WHEN 'BASIC' THEN 9900
+           WHEN 'PRO' THEN 14900
+       END,
+       'KRW',
+       CASE plan_tier::text
+           WHEN 'FREE' THEN 'LIFETIME'
+           ELSE 'MONTHLY'
+       END
+FROM subscription_product
+WHERE plan_tier::text IN ('FREE', 'BASIC', 'PRO')
+ON CONFLICT (product_id, billing_cycle, currency) DO UPDATE
+SET price = EXCLUDED.price;
+
+INSERT INTO interview_quota (plan_tier, daily_limit, max_questions_per_session)
+VALUES
+    ('FREE', 1, 3),
+    ('BASIC', 5, 5),
+    ('PRO', 15, 10)
+ON CONFLICT (plan_tier) DO UPDATE
+SET daily_limit = EXCLUDED.daily_limit,
+    max_questions_per_session = EXCLUDED.max_questions_per_session;
+
+COMMIT;

--- a/src/main/java/app/mockly/domain/auth/controller/AuthController.java
+++ b/src/main/java/app/mockly/domain/auth/controller/AuthController.java
@@ -5,11 +5,9 @@ import app.mockly.domain.auth.dto.request.*;
 import app.mockly.domain.auth.dto.response.LoginResponse;
 import app.mockly.domain.auth.dto.response.RefreshTokenResponse;
 import app.mockly.domain.auth.service.AuthService;
-import app.mockly.domain.auth.service.JwtService;
 import app.mockly.global.common.ApiResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.context.annotation.Profile;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
@@ -60,12 +58,5 @@ public class AuthController {
         }
         authService.logout(accessToken, request.refreshToken());
         return ResponseEntity.ok(ApiResponse.noContent());
-    }
-
-    @PostMapping("/dev/login")
-    @Profile("!prod")
-    public ResponseEntity<ApiResponse<LoginResponse>> devLogin(@RequestBody DevLoginRequest request) {
-        LoginResponse loginResponse = authService.loginWithDev(request);
-        return ResponseEntity.ok(ApiResponse.success(loginResponse));
     }
 }

--- a/src/main/java/app/mockly/domain/auth/controller/DevAuthController.java
+++ b/src/main/java/app/mockly/domain/auth/controller/DevAuthController.java
@@ -1,0 +1,28 @@
+package app.mockly.domain.auth.controller;
+
+import app.mockly.domain.auth.dto.request.DevLoginRequest;
+import app.mockly.domain.auth.dto.response.LoginResponse;
+import app.mockly.domain.auth.service.AuthService;
+import app.mockly.global.common.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Profile;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Profile("dev")
+@RestController
+@RequestMapping("/api/auth/dev")
+@RequiredArgsConstructor
+public class DevAuthController {
+
+    private final AuthService authService;
+
+    @PostMapping("/login")
+    public ResponseEntity<ApiResponse<LoginResponse>> devLogin(@RequestBody DevLoginRequest request) {
+        LoginResponse loginResponse = authService.loginWithDev(request);
+        return ResponseEntity.ok(ApiResponse.success(loginResponse));
+    }
+}

--- a/src/main/java/app/mockly/global/handler/GlobalExceptionHandler.java
+++ b/src/main/java/app/mockly/global/handler/GlobalExceptionHandler.java
@@ -12,6 +12,7 @@ import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.servlet.resource.NoResourceFoundException;
 
 import java.util.stream.Collectors;
 
@@ -51,6 +52,14 @@ public class GlobalExceptionHandler {
                         ApiStatusCode.VALIDATION_ERROR.getCode(),
                         errorMessage.isEmpty() ? ApiStatusCode.VALIDATION_ERROR.getMessage() : errorMessage
                 ));
+    }
+
+    @ExceptionHandler(NoResourceFoundException.class)
+    public ResponseEntity<ApiResponse<Void>> handleNoResourceFoundException(NoResourceFoundException e) {
+        ApiStatusCode statusCode = ApiStatusCode.RESOURCE_NOT_FOUND;
+        return ResponseEntity
+                .status(statusCode.getStatus())
+                .body(ApiResponse.error(statusCode.getCode(), statusCode.getMessage()));
     }
 
     @ExceptionHandler(Exception.class)

--- a/src/main/resources/application-preprod.yaml
+++ b/src/main/resources/application-preprod.yaml
@@ -1,0 +1,33 @@
+spring:
+  jpa:
+    hibernate:
+      ddl-auto: update
+    show-sql: false
+    properties:
+      hibernate:
+        format_sql: false
+  sql:
+    init:
+      mode: never
+
+springdoc:
+  api-docs:
+    enabled: false
+  swagger-ui:
+    enabled: false
+
+logging:
+  level:
+    root: INFO
+    app.mockly: INFO
+    org.springframework.security.web.FilterChainProxy: INFO
+    org.springframework.security.web.util.matcher: INFO
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health
+  endpoint:
+    health:
+      show-details: never

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -26,6 +26,7 @@ spring:
       host: ${REDIS_HOST:localhost}
       port: ${REDIS_PORT:6379}
       password: ${REDIS_PASSWORD}
+      database: ${REDIS_DATABASE:0}
 
 #  # H2 콘솔 활성화 (개발 편의성)
 #  h2:

--- a/src/test/java/app/mockly/deployment/PreprodDeploymentArtifactsTest.java
+++ b/src/test/java/app/mockly/deployment/PreprodDeploymentArtifactsTest.java
@@ -1,0 +1,111 @@
+package app.mockly.deployment;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.yaml.snakeyaml.Yaml;
+
+import java.io.IOException;
+import java.io.Reader;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class PreprodDeploymentArtifactsTest {
+
+    private static final Path COMPOSE_FILE = Path.of("deploy/preprod/docker-compose.yml");
+    private static final Path SEED_FILE = Path.of("deploy/preprod/seed.sql");
+
+    @Test
+    @DisplayName("pre-prod Compose는 dev와 분리된 라우팅과 자원 제한을 사용한다")
+    void composeIsIsolatedFromDev() throws IOException {
+        Map<String, Object> compose = loadYaml(COMPOSE_FILE);
+        Map<String, Object> services = map(compose.get("services"));
+        Map<String, Object> service = map(services.get("mockly-server-preprod"));
+        Map<String, Object> environment = map(service.get("environment"));
+        List<String> labels = list(service.get("labels"));
+        Map<String, Object> networks = map(compose.get("networks"));
+        Map<String, Object> network = map(networks.get("mockly-network"));
+
+        assertThat(service.get("container_name")).isEqualTo("mockly-server-preprod");
+        assertThat(service.get("image")).isEqualTo("mockly-server-preprod:${APP_IMAGE_TAG:-latest}");
+        assertThat(service.get("restart")).isEqualTo("unless-stopped");
+        assertThat(service.get("mem_limit")).isEqualTo("512m");
+        assertThat(service.get("cpus")).isEqualTo(0.75);
+        assertThat(environment)
+                .containsEntry("SPRING_PROFILES_ACTIVE", "preprod")
+                .containsEntry("POSTGRES_HOST", "mockly-postgres")
+                .containsEntry("POSTGRES_DB", "${POSTGRES_DB}")
+                .containsEntry("REDIS_HOST", "mockly-redis")
+                .containsEntry("REDIS_DATABASE", "${REDIS_DATABASE:-1}");
+        assertThat(labels)
+                .contains("traefik.enable=true")
+                .contains("traefik.docker.network=mockly-infra_mockly-network")
+                .contains("traefik.http.routers.mockly-preprod.rule=Host(`pre-prod.kancho.co`)")
+                .contains("traefik.http.services.mockly-preprod.loadbalancer.server.port=8080");
+        assertThat(network)
+                .containsEntry("external", true)
+                .containsEntry("name", "mockly-infra_mockly-network");
+    }
+
+    @Test
+    @DisplayName("pre-prod Compose는 민감정보를 환경변수 참조로만 주입한다")
+    void composeDoesNotContainSecretValues() throws IOException {
+        Map<String, Object> compose = loadYaml(COMPOSE_FILE);
+        Map<String, Object> service = map(map(compose.get("services")).get("mockly-server-preprod"));
+        Map<String, Object> environment = map(service.get("environment"));
+
+        List<String> sensitiveNames = List.of(
+                "POSTGRES_PASSWORD",
+                "REDIS_PASSWORD",
+                "JWT_SECRET",
+                "GOOGLE_ANDROID_CLIENT_ID",
+                "PORTONE_API_SECRET",
+                "PORTONE_WEBHOOK_SECRET",
+                "OPENAI_API_KEY"
+        );
+
+        for (String name : sensitiveNames) {
+            assertThat(environment.get(name))
+                    .as(name + " must be injected through Compose interpolation")
+                    .isInstanceOf(String.class)
+                    .asString()
+                    .startsWith("${");
+        }
+    }
+
+    @Test
+    @DisplayName("pre-prod seed는 기준 데이터의 고유키를 사용해 재실행할 수 있다")
+    void seedUsesIdempotentKeys() throws IOException {
+        String seedSql = Files.readString(SEED_FILE);
+
+        assertThat(seedSql)
+                .contains("ON CONFLICT (name) DO UPDATE")
+                .contains("ON CONFLICT (plan_id, currency) DO UPDATE")
+                .contains("WHERE NOT EXISTS")
+                .contains("ON CONFLICT (product_id, billing_cycle, currency) DO UPDATE")
+                .contains("ON CONFLICT (plan_tier) DO UPDATE")
+                .doesNotContain("INSERT INTO users")
+                .doesNotContain("INSERT INTO payment")
+                .doesNotContain("INSERT INTO refresh_token");
+    }
+
+    @SuppressWarnings("unchecked")
+    private Map<String, Object> loadYaml(Path path) throws IOException {
+        try (Reader reader = Files.newBufferedReader(path)) {
+            return new Yaml().load(reader);
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private Map<String, Object> map(Object value) {
+        return (Map<String, Object>) value;
+    }
+
+    @SuppressWarnings("unchecked")
+    private List<String> list(Object value) {
+        return (List<String>) value;
+    }
+}

--- a/src/test/java/app/mockly/domain/auth/controller/DevLoginDevProfileTest.java
+++ b/src/test/java/app/mockly/domain/auth/controller/DevLoginDevProfileTest.java
@@ -1,0 +1,49 @@
+package app.mockly.domain.auth.controller;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("dev")
+@Transactional
+class DevLoginDevProfileTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    @DisplayName("dev 프로필에서는 dev 로그인 엔드포인트를 제공한다")
+    void devLoginIsAvailableInDev() throws Exception {
+        mockMvc.perform(post("/api/auth/dev/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "email": "dev-test@example.com",
+                                  "name": "Dev Test",
+                                  "deviceInfo": {
+                                    "deviceId": "dev-device",
+                                    "deviceName": "Dev Device"
+                                  },
+                                  "locationInfo": {
+                                    "latitude": 37.0,
+                                    "longitude": 127.0
+                                  }
+                                }
+                                """))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.user.email").value("dev-test@example.com"));
+    }
+}

--- a/src/test/java/app/mockly/domain/auth/controller/DevLoginPreprodIsolationTest.java
+++ b/src/test/java/app/mockly/domain/auth/controller/DevLoginPreprodIsolationTest.java
@@ -1,0 +1,49 @@
+package app.mockly.domain.auth.controller;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("preprod")
+@Transactional
+class DevLoginPreprodIsolationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    @DisplayName("pre-prod 프로필에서는 dev 로그인 엔드포인트를 제공하지 않는다")
+    void devLoginIsNotAvailableInPreprod() throws Exception {
+        mockMvc.perform(post("/api/auth/dev/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "email": "preprod-test@example.com",
+                                  "name": "Preprod Test",
+                                  "deviceInfo": {
+                                    "deviceId": "preprod-device",
+                                    "deviceName": "Preprod Device"
+                                  },
+                                  "locationInfo": {
+                                    "latitude": 37.0,
+                                    "longitude": 127.0
+                                  }
+                                }
+                                """))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.error").value("RESOURCE_NOT_FOUND"));
+    }
+}

--- a/src/test/java/app/mockly/global/config/PreprodConfigurationTest.java
+++ b/src/test/java/app/mockly/global/config/PreprodConfigurationTest.java
@@ -1,0 +1,50 @@
+package app.mockly.global.config;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.env.YamlPropertySourceLoader;
+import org.springframework.core.env.PropertySource;
+import org.springframework.core.io.FileSystemResource;
+
+import java.io.IOException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class PreprodConfigurationTest {
+
+    private final YamlPropertySourceLoader loader = new YamlPropertySourceLoader();
+
+    @Test
+    @DisplayName("공통 설정은 Redis database index 환경변수를 지원한다")
+    void commonConfigurationSupportsRedisDatabaseIndex() throws IOException {
+        PropertySource<?> common = load("application.yaml");
+
+        assertThat(common.getProperty("spring.data.redis.database"))
+                .isEqualTo("${REDIS_DATABASE:0}");
+    }
+
+    @Test
+    @DisplayName("pre-prod 설정은 민감한 개발 로그와 Swagger UI를 비활성화한다")
+    void preprodConfigurationDisablesDevelopmentDiagnostics() throws IOException {
+        PropertySource<?> preprod = load("application-preprod.yaml");
+
+        assertThat(preprod.getProperty("spring.jpa.show-sql")).isEqualTo(false);
+        assertThat(preprod.getProperty("spring.sql.init.mode")).isEqualTo("never");
+        assertThat(preprod.getProperty("springdoc.api-docs.enabled")).isEqualTo(false);
+        assertThat(preprod.getProperty("springdoc.swagger-ui.enabled")).isEqualTo(false);
+        assertThat(preprod.getProperty("management.endpoints.web.exposure.include")).isEqualTo("health");
+        assertThat(preprod.getProperty("logging.level.root")).isEqualTo("INFO");
+        assertThat(preprod.getProperty("logging.level.app.mockly")).isEqualTo("INFO");
+        assertThat(preprod.getProperty("logging.level.org.springframework.security.web.FilterChainProxy"))
+                .isEqualTo("INFO");
+        assertThat(preprod.getProperty("logging.level.org.springframework.security.web.util.matcher"))
+                .isEqualTo("INFO");
+    }
+
+    private PropertySource<?> load(String resourceName) throws IOException {
+        return loader.load(
+                resourceName,
+                new FileSystemResource("src/main/resources/" + resourceName)
+        ).getFirst();
+    }
+}


### PR DESCRIPTION
## 작업 내용

- pre-prod 전용 Spring 프로필을 추가하고 Swagger·Prometheus 외부 노출을 제한했습니다.
- `pre-prod.kancho.co`용 Compose/Traefik 구성, 컨테이너 자원 제한, healthcheck를 추가했습니다.
- PostgreSQL·Redis를 dev와 분리할 수 있도록 환경변수와 기준 데이터 seed 구성을 추가했습니다.
- dev 전용 로그인 API를 `dev` 프로필로 제한하고, pre-prod에서는 표준 404로 응답하도록 했습니다.
- 실제 환경변수와 비공개 배포 문서는 Git 추적에서 제외했습니다.

## 검증

- `./gradlew clean test`
- `docker compose --env-file deploy/preprod/.env.preprod.example -f deploy/preprod/docker-compose.yml config --quiet`
- `git diff --check`

## 배포 후 확인 예정

- pre-prod HTTPS, healthcheck, DB·Redis 격리
- 인증 API 및 dev 로그인 API 비노출
- OpenAI API 호출과 dev 환경 연속성

Closes #36