### PR TITLE
feat: User-Agent로 클라이언트 플랫폼 추론

### DIFF
--- a/src/main/java/app/mockly/domain/auth/controller/AuthController.java
+++ b/src/main/java/app/mockly/domain/auth/controller/AuthController.java
@@ -1,5 +1,6 @@
 package app.mockly.domain.auth.controller;
 
+import app.mockly.domain.auth.dto.Platform;
 import app.mockly.domain.auth.dto.UserInfo;
 import app.mockly.domain.auth.dto.request.*;
 import app.mockly.domain.auth.dto.response.LoginResponse;
@@ -8,6 +9,8 @@ import app.mockly.domain.auth.service.AuthService;
 import app.mockly.global.common.ApiResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
@@ -17,18 +20,25 @@ import java.util.UUID;
 @RestController
 @RequestMapping("/api/auth")
 @RequiredArgsConstructor
+@Slf4j
 public class AuthController {
     private final AuthService authService;
 
     @PostMapping("/login/google/code")
-    public ResponseEntity<ApiResponse<LoginResponse>> loginWithGoogleCode(@Valid @RequestBody AuthorizationCodeRequest request) {
+    public ResponseEntity<ApiResponse<LoginResponse>> loginWithGoogleCode(
+            @Valid @RequestBody AuthorizationCodeRequest request,
+            @RequestHeader(value = HttpHeaders.USER_AGENT, required = false) String userAgent
+    ) {
+        Platform platform = Platform.resolve(request.platform(), userAgent);
+        log.info("Google 로그인 플랫폼 해석: platform={} source={}", platform, Platform.resolveSource(request.platform()));
+
         LoginResponse loginResponse = authService.loginWithGoogleCode(
                 request.code(),
                 request.codeVerifier(),
                 request.redirectUri(),
                 request.deviceInfo(),
                 request.locationInfo(),
-                request.platform());
+                platform);
         return ResponseEntity.ok(ApiResponse.success(loginResponse));
     }
 

--- a/src/main/java/app/mockly/domain/auth/controller/AuthController.java
+++ b/src/main/java/app/mockly/domain/auth/controller/AuthController.java
@@ -29,8 +29,8 @@ public class AuthController {
             @Valid @RequestBody AuthorizationCodeRequest request,
             @RequestHeader(value = HttpHeaders.USER_AGENT, required = false) String userAgent
     ) {
-        Platform platform = Platform.resolve(request.platform(), userAgent);
-        log.info("Google 로그인 플랫폼 해석: platform={} source={}", platform, Platform.resolveSource(request.platform()));
+        Platform platform = Platform.fromUserAgent(userAgent);
+        log.info("Google 로그인 플랫폼 판별: platform={} userAgent={}", platform, userAgent);
 
         LoginResponse loginResponse = authService.loginWithGoogleCode(
                 request.code(),

--- a/src/main/java/app/mockly/domain/auth/dto/Platform.java
+++ b/src/main/java/app/mockly/domain/auth/dto/Platform.java
@@ -6,44 +6,29 @@ public enum Platform {
     ANDROID,
     IOS;
 
-    // ponytail: 클라이언트가 platform을 안 보내던 시절의 요청은 전부 Android였다
+    // ponytail: 판별 불가 시 ANDROID. 첫 클라이언트가 Android였고 지금도 대부분이다
     public static final Platform DEFAULT = ANDROID;
-
-    /**
-     * 요청 본문의 platform을 우선 사용하고, 없으면 User-Agent로 추론한다.
-     * <p>
-     * User-Agent 추론은 명시적 계약이 아니라 폴백이다. 앱이 HTTP 스택을 바꾸면
-     * (예: Flutter의 {@code Dart/3.x (dart:io)}) 아래 시그니처가 사라져 ANDROID로 잘못 잡힌다.
-     * 클라이언트가 platform을 보내기 시작하면 이 경로는 타지 않는다.
-     */
-    public static Platform resolve(Platform requested, String userAgent) {
-        if (requested != null) {
-            return requested;
-        }
-        return fromUserAgent(userAgent);
-    }
 
     /**
      * 애플 클라이언트가 User-Agent에 남기는 시그니처.
      * <p>
      * URLSession은 {@code mockly/1 CFNetwork/3860.100.1 Darwin/25.5.0}처럼 CFNetwork/Darwin을 붙이지만,
      * Alamofire는 UA를 직접 덮어써서 {@code Mockly/2.0 (com.mockly.app; iOS 18.0) Alamofire/5.9.1}처럼
-     * 플랫폼명만 남는다. ios는 단어 경계로 매칭해 {@code axios/1.6.0} 같은 HTTP 클라이언트명과 구분한다.
+     * 플랫폼명만 남긴다. ios는 단어 경계로 매칭해 {@code axios/1.6.0} 같은 HTTP 클라이언트명과 구분한다.
      */
     private static final Pattern APPLE_SIGNATURE =
             Pattern.compile("cfnetwork|darwin|iphone|ipad|\\bios\\b", Pattern.CASE_INSENSITIVE);
 
+    /**
+     * User-Agent로 클라이언트 플랫폼을 추론한다.
+     * <p>
+     * UA는 우리가 통제하는 값이 아니다. 앱이 HTTP 스택을 교체하면(예: Flutter의 {@code Dart/3.x (dart:io)})
+     * 시그니처가 사라져 ANDROID로 잘못 잡히고, 증상은 조용한 401이다. 판별 결과는 반드시 로그로 남긴다.
+     */
     public static Platform fromUserAgent(String userAgent) {
         if (userAgent == null) {
             return DEFAULT;
         }
         return APPLE_SIGNATURE.matcher(userAgent).find() ? IOS : DEFAULT;
-    }
-
-    /**
-     * 어떤 근거로 플랫폼이 정해졌는지. 로그로 남겨 오판을 추적한다.
-     */
-    public static String resolveSource(Platform requested) {
-        return requested != null ? "request" : "user-agent";
     }
 }

--- a/src/main/java/app/mockly/domain/auth/dto/Platform.java
+++ b/src/main/java/app/mockly/domain/auth/dto/Platform.java
@@ -1,9 +1,49 @@
 package app.mockly.domain.auth.dto;
 
+import java.util.regex.Pattern;
+
 public enum Platform {
     ANDROID,
     IOS;
 
     // ponytail: 클라이언트가 platform을 안 보내던 시절의 요청은 전부 Android였다
     public static final Platform DEFAULT = ANDROID;
+
+    /**
+     * 요청 본문의 platform을 우선 사용하고, 없으면 User-Agent로 추론한다.
+     * <p>
+     * User-Agent 추론은 명시적 계약이 아니라 폴백이다. 앱이 HTTP 스택을 바꾸면
+     * (예: Flutter의 {@code Dart/3.x (dart:io)}) 아래 시그니처가 사라져 ANDROID로 잘못 잡힌다.
+     * 클라이언트가 platform을 보내기 시작하면 이 경로는 타지 않는다.
+     */
+    public static Platform resolve(Platform requested, String userAgent) {
+        if (requested != null) {
+            return requested;
+        }
+        return fromUserAgent(userAgent);
+    }
+
+    /**
+     * 애플 클라이언트가 User-Agent에 남기는 시그니처.
+     * <p>
+     * URLSession은 {@code mockly/1 CFNetwork/3860.100.1 Darwin/25.5.0}처럼 CFNetwork/Darwin을 붙이지만,
+     * Alamofire는 UA를 직접 덮어써서 {@code Mockly/2.0 (com.mockly.app; iOS 18.0) Alamofire/5.9.1}처럼
+     * 플랫폼명만 남는다. ios는 단어 경계로 매칭해 {@code axios/1.6.0} 같은 HTTP 클라이언트명과 구분한다.
+     */
+    private static final Pattern APPLE_SIGNATURE =
+            Pattern.compile("cfnetwork|darwin|iphone|ipad|\\bios\\b", Pattern.CASE_INSENSITIVE);
+
+    public static Platform fromUserAgent(String userAgent) {
+        if (userAgent == null) {
+            return DEFAULT;
+        }
+        return APPLE_SIGNATURE.matcher(userAgent).find() ? IOS : DEFAULT;
+    }
+
+    /**
+     * 어떤 근거로 플랫폼이 정해졌는지. 로그로 남겨 오판을 추적한다.
+     */
+    public static String resolveSource(Platform requested) {
+        return requested != null ? "request" : "user-agent";
+    }
 }

--- a/src/main/java/app/mockly/domain/auth/dto/request/AuthorizationCodeRequest.java
+++ b/src/main/java/app/mockly/domain/auth/dto/request/AuthorizationCodeRequest.java
@@ -18,11 +18,6 @@ public record AuthorizationCodeRequest(
         @NotNull(message = "deviceInfo는 필수입니다.")
         DeviceInfo deviceInfo,
         LocationInfo locationInfo, // Optional
-        Platform platform // Optional, 미전송 시 ANDROID
+        Platform platform // Optional, 미전송 시 User-Agent로 추론 (Platform.resolve)
 ) {
-    public AuthorizationCodeRequest {
-        if (platform == null) {
-            platform = Platform.DEFAULT;
-        }
-    }
 }

--- a/src/main/java/app/mockly/domain/auth/dto/request/AuthorizationCodeRequest.java
+++ b/src/main/java/app/mockly/domain/auth/dto/request/AuthorizationCodeRequest.java
@@ -2,7 +2,6 @@ package app.mockly.domain.auth.dto.request;
 
 import app.mockly.domain.auth.dto.DeviceInfo;
 import app.mockly.domain.auth.dto.LocationInfo;
-import app.mockly.domain.auth.dto.Platform;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
@@ -17,7 +16,6 @@ public record AuthorizationCodeRequest(
         @Valid
         @NotNull(message = "deviceInfo는 필수입니다.")
         DeviceInfo deviceInfo,
-        LocationInfo locationInfo, // Optional
-        Platform platform // Optional, 미전송 시 User-Agent로 추론 (Platform.resolve)
+        LocationInfo locationInfo // Optional
 ) {
 }

--- a/src/main/java/app/mockly/domain/auth/service/GoogleOAuthService.java
+++ b/src/main/java/app/mockly/domain/auth/service/GoogleOAuthService.java
@@ -12,10 +12,12 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.http.MediaType;
+import org.springframework.http.client.ClientHttpResponse;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestClient;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.security.GeneralSecurityException;
 
 @Service
@@ -37,7 +39,10 @@ public class GoogleOAuthService {
                         "&code_verifier=" + codeVerifier)
                 .retrieve()
                 .onStatus(HttpStatusCode::is4xxClientError, (req, res) -> {
-                    log.error("Google Token 교환 실패: {}", res.getStatusCode());
+                    // Google 응답 본문에는 error/error_description만 담기므로 로그로 남겨도 안전하다.
+                    // code와 code_verifier는 자격증명이므로 절대 남기지 않는다.
+                    log.error("Google Token 교환 실패: status={} platform={} redirectUri={} response={}",
+                            res.getStatusCode(), platform, redirectUri, readErrorBody(res));
                     throw new InvalidTokenException(ApiStatusCode.INVALID_GOOGLE_TOKEN, "Google 인증 코드가 유효하지 않습니다");
                 })
                 .onStatus(HttpStatusCode::is5xxServerError, (req, res) -> {
@@ -51,6 +56,14 @@ public class GoogleOAuthService {
             throw new InvalidTokenException(ApiStatusCode.INVALID_TOKEN, "Google Token 교환에 실패했습니다");
         }
         return googleToken.idToken();
+    }
+
+    private String readErrorBody(ClientHttpResponse response) {
+        try {
+            return new String(response.getBody().readAllBytes(), StandardCharsets.UTF_8);
+        } catch (IOException e) {
+            return "(본문 읽기 실패: " + e.getMessage() + ")";
+        }
     }
 
     public GoogleUser verifyIdToken(String idToken) {

--- a/src/test/java/app/mockly/domain/auth/controller/AuthControllerTest.java
+++ b/src/test/java/app/mockly/domain/auth/controller/AuthControllerTest.java
@@ -162,7 +162,7 @@ class AuthControllerTest {
     }
 
     @Test
-    @DisplayName("POST /api/auth/login/google/code - platform 미전송 시 ANDROID, 전송 시 해당 플랫폼 client id로 교환")
+    @DisplayName("POST /api/auth/login/google/code - platform은 요청 본문 > User-Agent > ANDROID 순으로 해석한다")
     void loginWithGoogleCode_ResolvesPlatform() throws Exception {
         given(googleOAuthService.exchangeAuthorizationCode(anyString(), anyString(), anyString(), any()))
                 .willReturn("mock-id-token");
@@ -195,10 +195,25 @@ class AuthControllerTest {
                                 """))
                 .andExpect(status().isOk());
 
+        // platform 미전송 + 애플 네이티브 User-Agent -> IOS로 추론
+        mockMvc.perform(post("/api/auth/login/google/code")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .header("User-Agent", "mockly/1 CFNetwork/3860.100.1 Darwin/25.5.0")
+                        .content("""
+                                {
+                                  "code": "test-auth-code",
+                                  "codeVerifier": "test-code-verifier",
+                                  "redirectUri": "https://mockly.app/oauth2/google/redirect",
+                                  "deviceInfo": {"deviceId": "ios-ua-device", "deviceName": "iPhone"}
+                                }
+                                """))
+                .andExpect(status().isOk());
+
         ArgumentCaptor<Platform> platformCaptor = ArgumentCaptor.forClass(Platform.class);
-        verify(googleOAuthService, times(2))
+        verify(googleOAuthService, times(3))
                 .exchangeAuthorizationCode(anyString(), anyString(), anyString(), platformCaptor.capture());
-        assertThat(platformCaptor.getAllValues()).containsExactly(Platform.ANDROID, Platform.IOS);
+        assertThat(platformCaptor.getAllValues())
+                .containsExactly(Platform.ANDROID, Platform.IOS, Platform.IOS);
     }
 
     @Test

--- a/src/test/java/app/mockly/domain/auth/controller/AuthControllerTest.java
+++ b/src/test/java/app/mockly/domain/auth/controller/AuthControllerTest.java
@@ -141,8 +141,7 @@ class AuthControllerTest {
             "test-code-verifier",
             "https://mockly.app/oauth2/google/redirect",
                 new DeviceInfo("uuid-from-client", "device-name"),
-                new LocationInfo(127.0, 135.0),
-                Platform.ANDROID
+                new LocationInfo(127.0, 135.0)
         );
 
         // when & then
@@ -162,58 +161,45 @@ class AuthControllerTest {
     }
 
     @Test
-    @DisplayName("POST /api/auth/login/google/code - platform은 요청 본문 > User-Agent > ANDROID 순으로 해석한다")
+    @DisplayName("POST /api/auth/login/google/code - User-Agent로 플랫폼을 판별해 교환한다")
     void loginWithGoogleCode_ResolvesPlatform() throws Exception {
         given(googleOAuthService.exchangeAuthorizationCode(anyString(), anyString(), anyString(), any()))
                 .willReturn("mock-id-token");
         given(googleOAuthService.verifyIdToken(anyString()))
                 .willReturn(new GoogleUser("google-user-id-456", "ios@mockly.com", "iOS User", true));
 
-        // platform 필드가 아예 없는 기존 Android 클라이언트 요청
-        mockMvc.perform(post("/api/auth/login/google/code")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content("""
-                                {
-                                  "code": "test-auth-code",
-                                  "codeVerifier": "test-code-verifier",
-                                  "redirectUri": "https://mockly.app/oauth2/google/redirect",
-                                  "deviceInfo": {"deviceId": "no-platform-device", "deviceName": "device-name"}
-                                }
-                                """))
-                .andExpect(status().isOk());
+        String requestBody = """
+                {
+                  "code": "test-auth-code",
+                  "codeVerifier": "test-code-verifier",
+                  "redirectUri": "https://mockly.app/oauth2/google/redirect",
+                  "deviceInfo": {"deviceId": "%s", "deviceName": "device-name"}
+                }
+                """;
 
         mockMvc.perform(post("/api/auth/login/google/code")
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content("""
-                                {
-                                  "code": "test-auth-code",
-                                  "codeVerifier": "test-code-verifier",
-                                  "redirectUri": "https://mockly.app/oauth2/google/redirect",
-                                  "deviceInfo": {"deviceId": "ios-device", "deviceName": "iPhone"},
-                                  "platform": "IOS"
-                                }
-                                """))
+                        .header("User-Agent", "okhttp/4.12.0")
+                        .content(requestBody.formatted("android-device")))
                 .andExpect(status().isOk());
 
-        // platform 미전송 + 애플 네이티브 User-Agent -> IOS로 추론
         mockMvc.perform(post("/api/auth/login/google/code")
                         .contentType(MediaType.APPLICATION_JSON)
                         .header("User-Agent", "mockly/1 CFNetwork/3860.100.1 Darwin/25.5.0")
-                        .content("""
-                                {
-                                  "code": "test-auth-code",
-                                  "codeVerifier": "test-code-verifier",
-                                  "redirectUri": "https://mockly.app/oauth2/google/redirect",
-                                  "deviceInfo": {"deviceId": "ios-ua-device", "deviceName": "iPhone"}
-                                }
-                                """))
+                        .content(requestBody.formatted("ios-device")))
+                .andExpect(status().isOk());
+
+        // User-Agent가 없는 요청은 ANDROID로 처리한다
+        mockMvc.perform(post("/api/auth/login/google/code")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestBody.formatted("no-ua-device")))
                 .andExpect(status().isOk());
 
         ArgumentCaptor<Platform> platformCaptor = ArgumentCaptor.forClass(Platform.class);
         verify(googleOAuthService, times(3))
                 .exchangeAuthorizationCode(anyString(), anyString(), anyString(), platformCaptor.capture());
         assertThat(platformCaptor.getAllValues())
-                .containsExactly(Platform.ANDROID, Platform.IOS, Platform.IOS);
+                .containsExactly(Platform.ANDROID, Platform.IOS, Platform.ANDROID);
     }
 
     @Test

--- a/src/test/java/app/mockly/domain/auth/controller/docs/LoginWithGoogleCodeDocs.java
+++ b/src/test/java/app/mockly/domain/auth/controller/docs/LoginWithGoogleCodeDocs.java
@@ -19,7 +19,7 @@ public class LoginWithGoogleCodeDocs {
             fieldWithPath("deviceInfo").description("디바이스 정보").type(JsonFieldType.OBJECT),
             fieldWithPath("deviceInfo.deviceId").description("디바이스 고유 ID").type(SimpleType.STRING),
             fieldWithPath("deviceInfo.deviceName").description("디바이스 이름").type(SimpleType.STRING),
-            fieldWithPath("platform").description("클라이언트 플랫폼 (선택, ANDROID | IOS, 미전송 시 ANDROID)").type(SimpleType.STRING).optional(),
+            fieldWithPath("platform").description("클라이언트 플랫폼 (선택, ANDROID | IOS). 미전송 시 User-Agent로 추론하며 판별 불가 시 ANDROID").type(SimpleType.STRING).optional(),
             fieldWithPath("locationInfo").description("위치 정보 (선택)").type(JsonFieldType.OBJECT).optional(),
             fieldWithPath("locationInfo.latitude").description("위도").type(SimpleType.NUMBER).optional(),
             fieldWithPath("locationInfo.longitude").description("경도").type(SimpleType.NUMBER).optional()

--- a/src/test/java/app/mockly/domain/auth/controller/docs/LoginWithGoogleCodeDocs.java
+++ b/src/test/java/app/mockly/domain/auth/controller/docs/LoginWithGoogleCodeDocs.java
@@ -19,7 +19,6 @@ public class LoginWithGoogleCodeDocs {
             fieldWithPath("deviceInfo").description("디바이스 정보").type(JsonFieldType.OBJECT),
             fieldWithPath("deviceInfo.deviceId").description("디바이스 고유 ID").type(SimpleType.STRING),
             fieldWithPath("deviceInfo.deviceName").description("디바이스 이름").type(SimpleType.STRING),
-            fieldWithPath("platform").description("클라이언트 플랫폼 (선택, ANDROID | IOS). 미전송 시 User-Agent로 추론하며 판별 불가 시 ANDROID").type(SimpleType.STRING).optional(),
             fieldWithPath("locationInfo").description("위치 정보 (선택)").type(JsonFieldType.OBJECT).optional(),
             fieldWithPath("locationInfo.latitude").description("위도").type(SimpleType.NUMBER).optional(),
             fieldWithPath("locationInfo.longitude").description("경도").type(SimpleType.NUMBER).optional()

--- a/src/test/java/app/mockly/domain/auth/dto/PlatformTest.java
+++ b/src/test/java/app/mockly/domain/auth/dto/PlatformTest.java
@@ -1,0 +1,49 @@
+package app.mockly.domain.auth.dto;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class PlatformTest {
+
+    // 실제 pre-prod traefik 접근 로그에서 관측된 값
+    private static final String IOS_USER_AGENT = "mockly/1 CFNetwork/3860.100.1 Darwin/25.5.0";
+    private static final String ANDROID_USER_AGENT = "okhttp/4.12.0";
+
+    @Test
+    @DisplayName("요청 본문의 platform이 User-Agent보다 우선한다")
+    void requestedPlatformWinsOverUserAgent() {
+        assertThat(Platform.resolve(Platform.ANDROID, IOS_USER_AGENT)).isEqualTo(Platform.ANDROID);
+        assertThat(Platform.resolve(Platform.IOS, ANDROID_USER_AGENT)).isEqualTo(Platform.IOS);
+    }
+
+    @Test
+    @DisplayName("platform 미전송 시 애플 네이티브 User-Agent는 IOS로 판별한다")
+    void appleUserAgentResolvesToIos() {
+        assertThat(Platform.resolve(null, IOS_USER_AGENT)).isEqualTo(Platform.IOS);
+        assertThat(Platform.resolve(null, "Mockly/2.0 (com.mockly.app; iOS 18.0) Alamofire/5.9.1")).isEqualTo(Platform.IOS);
+    }
+
+    @Test
+    @DisplayName("애플 시그니처가 없거나 User-Agent가 없으면 ANDROID로 처리한다")
+    void otherUserAgentsFallBackToAndroid() {
+        assertThat(Platform.resolve(null, ANDROID_USER_AGENT)).isEqualTo(Platform.ANDROID);
+        assertThat(Platform.resolve(null, null)).isEqualTo(Platform.ANDROID);
+        assertThat(Platform.resolve(null, "")).isEqualTo(Platform.ANDROID);
+    }
+
+    @Test
+    @DisplayName("HTTP 클라이언트 이름에 포함된 ios는 애플로 오판하지 않는다")
+    void httpClientNamesAreNotMistakenForIos() {
+        assertThat(Platform.resolve(null, "axios/1.6.0")).isEqualTo(Platform.ANDROID);
+        assertThat(Platform.resolve(null, "Dart/3.4 (dart:io)")).isEqualTo(Platform.ANDROID);
+    }
+
+    @Test
+    @DisplayName("판별 근거를 로그로 구분할 수 있다")
+    void exposesResolveSource() {
+        assertThat(Platform.resolveSource(Platform.IOS)).isEqualTo("request");
+        assertThat(Platform.resolveSource(null)).isEqualTo("user-agent");
+    }
+}

--- a/src/test/java/app/mockly/domain/auth/dto/PlatformTest.java
+++ b/src/test/java/app/mockly/domain/auth/dto/PlatformTest.java
@@ -7,43 +7,31 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 class PlatformTest {
 
-    // 실제 pre-prod traefik 접근 로그에서 관측된 값
+    // 실제 traefik 접근 로그에서 관측된 iOS 앱의 User-Agent
     private static final String IOS_USER_AGENT = "mockly/1 CFNetwork/3860.100.1 Darwin/25.5.0";
-    private static final String ANDROID_USER_AGENT = "okhttp/4.12.0";
 
     @Test
-    @DisplayName("요청 본문의 platform이 User-Agent보다 우선한다")
-    void requestedPlatformWinsOverUserAgent() {
-        assertThat(Platform.resolve(Platform.ANDROID, IOS_USER_AGENT)).isEqualTo(Platform.ANDROID);
-        assertThat(Platform.resolve(Platform.IOS, ANDROID_USER_AGENT)).isEqualTo(Platform.IOS);
-    }
-
-    @Test
-    @DisplayName("platform 미전송 시 애플 네이티브 User-Agent는 IOS로 판별한다")
+    @DisplayName("애플 네이티브 User-Agent는 IOS로 판별한다")
     void appleUserAgentResolvesToIos() {
-        assertThat(Platform.resolve(null, IOS_USER_AGENT)).isEqualTo(Platform.IOS);
-        assertThat(Platform.resolve(null, "Mockly/2.0 (com.mockly.app; iOS 18.0) Alamofire/5.9.1")).isEqualTo(Platform.IOS);
+        assertThat(Platform.fromUserAgent(IOS_USER_AGENT)).isEqualTo(Platform.IOS);
+        // Alamofire는 UA를 덮어써서 CFNetwork/Darwin이 남지 않는다
+        assertThat(Platform.fromUserAgent("Mockly/2.0 (com.mockly.app; iOS 18.0) Alamofire/5.9.1"))
+                .isEqualTo(Platform.IOS);
+        assertThat(Platform.fromUserAgent("Mockly/1.0 (iPhone; iOS 17.5)")).isEqualTo(Platform.IOS);
     }
 
     @Test
     @DisplayName("애플 시그니처가 없거나 User-Agent가 없으면 ANDROID로 처리한다")
     void otherUserAgentsFallBackToAndroid() {
-        assertThat(Platform.resolve(null, ANDROID_USER_AGENT)).isEqualTo(Platform.ANDROID);
-        assertThat(Platform.resolve(null, null)).isEqualTo(Platform.ANDROID);
-        assertThat(Platform.resolve(null, "")).isEqualTo(Platform.ANDROID);
+        assertThat(Platform.fromUserAgent("okhttp/4.12.0")).isEqualTo(Platform.ANDROID);
+        assertThat(Platform.fromUserAgent(null)).isEqualTo(Platform.ANDROID);
+        assertThat(Platform.fromUserAgent("")).isEqualTo(Platform.ANDROID);
     }
 
     @Test
     @DisplayName("HTTP 클라이언트 이름에 포함된 ios는 애플로 오판하지 않는다")
     void httpClientNamesAreNotMistakenForIos() {
-        assertThat(Platform.resolve(null, "axios/1.6.0")).isEqualTo(Platform.ANDROID);
-        assertThat(Platform.resolve(null, "Dart/3.4 (dart:io)")).isEqualTo(Platform.ANDROID);
-    }
-
-    @Test
-    @DisplayName("판별 근거를 로그로 구분할 수 있다")
-    void exposesResolveSource() {
-        assertThat(Platform.resolveSource(Platform.IOS)).isEqualTo("request");
-        assertThat(Platform.resolveSource(null)).isEqualTo("user-agent");
+        assertThat(Platform.fromUserAgent("axios/1.6.0")).isEqualTo(Platform.ANDROID);
+        assertThat(Platform.fromUserAgent("Dart/3.4 (dart:io)")).isEqualTo(Platform.ANDROID);
     }
 }


### PR DESCRIPTION
## 개요

iOS 클라이언트가 플랫폼을 알려주지 않아 서버가 Android client ID로 토큰 교환을 시도했고, Google이 401로 거절해 iOS 로그인이 실패했다. 프론트 배포 없이 해결하기 위해 User-Agent로 플랫폼을 판별한다.

직전 PR에서 추가했던 요청 본문의 `platform` 필드는 제거하고 판별 경로를 하나로 유지한다. 두 경로를 함께 두면 어느 쪽이 적용됐는지 추적할 지점이 늘어나는데, 실제로 필드를 보내는 클라이언트가 없어 값을 못 한다.

## 주요 변경사항

### 🔐 User-Agent 기반 플랫폼 판별

애플 클라이언트가 남기는 시그니처 두 형태를 모두 다룬다. URLSession은 `mockly/1 CFNetwork/3860.100.1 Darwin/25.5.0`처럼 CFNetwork/Darwin을 붙이지만, Alamofire는 UA를 직접 덮어써서 `Mockly/2.0 (com.mockly.app; iOS 18.0) Alamofire/5.9.1`처럼 플랫폼명만 남긴다.

`ios`는 단어 경계로 매칭한다. 단순 substring이면 `axios/1.6.0`을 쓰는 클라이언트가 전부 iOS로 오판된다.

판별 불가 시 ANDROID로 처리해 기존 동작을 유지한다.

### 🔍 진단 로그

원인 추적이 로그 부재로 반복해서 막혔던 지점을 메운다.

- 판별된 platform과 근거가 된 User-Agent를 남겨 오판을 사후에 확인할 수 있게 한다
- Google 토큰 교환 4xx 응답 본문(`error`, `error_description`)을 platform, redirectUri와 함께 기록한다. 지금까지는 상태코드만 남겨 401의 원인이 `invalid_client`인지 확정할 수 없었다
- `code`와 `code_verifier`는 자격증명이므로 로그에 남기지 않는다

## 가이드

### 알아두어야 할 점

- **User-Agent는 우리가 통제하는 값이 아니다.** 앱이 HTTP 스택을 교체하거나(예: Flutter의 `Dart/3.x (dart:io)`) 웹 클라이언트가 추가되면 시그니처가 사라져 ANDROID로 잘못 잡히고, 증상은 조용한 401이다. 그때는 서버의 판별 규칙을 고쳐 배포해야 한다
- 판별이 틀려도 권한 상승은 없다. 잘못된 client ID로 교환을 시도하면 Google이 거절할 뿐이며, 보안 경계는 code 교환 자체다
- 직전 PR에서 문서화됐던 요청 본문 `platform` 필드가 사라진다. 보내더라도 무시될 뿐 오류가 되지는 않는다

## 다음에 해야 할 작업

- [ ] iOS 로그인 성공 확인 후 401의 실제 원인이 client ID 불일치였는지 로그로 검증
- [ ] 웹 클라이언트 추가 시 User-Agent 판별로는 구분이 불가능하므로 판별 방식 재검토